### PR TITLE
hide back button when search is open

### DIFF
--- a/rca/static_src/sass/components/_back-link.scss
+++ b/rca/static_src/sass/components/_back-link.scss
@@ -34,4 +34,9 @@
         fill: $color--white;
         transform: rotate(180deg);
     }
+
+    .search-active & {
+        visibility: hidden;
+        pointer-events: none;
+    }
 }


### PR DESCRIPTION
hide the back button when searching but keep it's spacing so the search is in the correct place