### PR TITLE
[119] Override basic auth get_client_ip function

### DIFF
--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -601,6 +601,10 @@ if env.get("BASIC_AUTH_ENABLED", "false").lower().strip() == "true":
             "BASIC_AUTH_WHITELISTED_HTTP_HOSTS"
         ].split(",")
 
+    # Change the get_client_ip function so we always get the real IP address and ignore
+    # the one passed in X-Forwarded-For. This is because all requests are proxied through
+    # the old site and we want to prevent direct access
+    BASIC_AUTH_GET_CLIENT_IP_FUNCTION = 'rca.utils.clientip.get_client_real_ip'
 
 AUTH_USER_MODEL = "users.User"
 

--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -604,7 +604,7 @@ if env.get("BASIC_AUTH_ENABLED", "false").lower().strip() == "true":
     # Change the get_client_ip function so we always get the real IP address and ignore
     # the one passed in X-Forwarded-For. This is because all requests are proxied through
     # the old site and we want to prevent direct access
-    BASIC_AUTH_GET_CLIENT_IP_FUNCTION = 'rca.utils.clientip.get_client_real_ip'
+    BASIC_AUTH_GET_CLIENT_IP_FUNCTION = "rca.utils.clientip.get_client_real_ip"
 
 AUTH_USER_MODEL = "users.User"
 

--- a/rca/utils/clientip.py
+++ b/rca/utils/clientip.py
@@ -6,4 +6,4 @@ def get_client_real_ip(request):
     The builtin get_client_ip function will use X-Forwarded-For if provided, but we want to check
     against the real IP address instead.
     """
-    return request.META.get('REMOTE_ADDR')
+    return request.META.get("REMOTE_ADDR")

--- a/rca/utils/clientip.py
+++ b/rca/utils/clientip.py
@@ -1,0 +1,9 @@
+def get_client_real_ip(request):
+    """
+    Gets the IP address of whatever is sending the request, ignoring X-Forwarded-For header.
+
+    We use the basic-auth-ip-whitelist plugin to prevent direct access to the backend webserver.
+    The builtin get_client_ip function will use X-Forwarded-For if provided, but we want to check
+    against the real IP address instead.
+    """
+    return request.META.get('REMOTE_ADDR')


### PR DESCRIPTION
So we always check against the real IP rather than X-Forwarded-For. This is so we can verify that requests went via the old site rather than direct.