### PR TITLE
Fix/181 docs download

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.html
+++ b/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.html
@@ -61,12 +61,4 @@
             </ul>
         </div>
     {% endif %}
-    {% if page.programme_specification.url %}
-        <div class="key-details__section key-details__section--action">
-            <a class="key-details__link link link--secondary link--download" href="{{ page.programme_specification.url }}">
-                <span class="link__label">Download the {{ page.title }} {{ page.degree_level }} programme specification</span>
-                <svg width="8" height="12" class="link__icon"><use xlink:href="#download"></use></svg>
-            </a>
-        </div>
-    {% endif %}
 </div>

--- a/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.html
+++ b/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.html
@@ -61,4 +61,12 @@
             </ul>
         </div>
     {% endif %}
+    {% if page.programme_specification.url %}
+        <div class="key-details__section key-details__section--action">
+            <a class="key-details__link link link--secondary link--download" href="{{ page.programme_specification.url }}">
+                <span class="link__label">Download the {{ page.title }} {{ page.degree_level }} programme specification</span>
+                <svg width="8" height="12" class="link__icon"><use xlink:href="#download"></use></svg>
+            </a>
+        </div>
+    {% endif %}
 </div>

--- a/rca/urls.py
+++ b/rca/urls.py
@@ -17,7 +17,7 @@ from rca.utils.cache import get_default_cache_control_decorator
 private_urlpatterns = [
     path("django-admin/", admin.site.urls),
     path("admin/", include(wagtailadmin_urls)),
-    path("documents/", include(wagtaildocs_urls)),
+    path("documents2/", include(wagtaildocs_urls)),
     # Search cache-control headers are set on the view itself.
     path("search/", search_views.search, name="search"),
 ]


### PR DESCRIPTION
[Ticket](https://projects.torchbox.com/projects/rca-website-rebuild/tickets/181) link

Because we are visiting over rca.ac.uk and proxying, the link for a document is 
 `href="/documents/1/Architecture_Programme_Specification_2018-19_11.pdf"`, this will result in `rca.ac.uk/documents/1/Architecture_Programme_Specification_2018-19_11.pdf` so we need to proxy this in a similar way to `static2`. 

This pr adjusts docs to serve over `documents2/`. We will need a corresponding proxy set up on the legacy site for documents2 to proxy `https://rca-production.herokuapp.com`
         