### PR TITLE
#255 Search results API

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,4 +5,4 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 
-known_third_party = dj_database_url,django,gunicorn,invoke,modelcluster,pattern_library,raven,requests,taggit,wagtail,wagtailcaptcha
+known_third_party = dj_database_url,django,gunicorn,invoke,modelcluster,pattern_library,raven,requests,rest_framework,taggit,wagtail,wagtailcaptcha

--- a/rca/programmes/models.py
+++ b/rca/programmes/models.py
@@ -52,6 +52,7 @@ class DegreeLevel(models.Model):
 def degree_level_serializer(*args, **kwargs):
     """Import the serializer, without a circular import error."""
     from rca.programmes.serializers import DegreeLevelSerializer
+
     return DegreeLevelSerializer(*args, **kwargs)
 
 

--- a/rca/programmes/models.py
+++ b/rca/programmes/models.py
@@ -15,6 +15,7 @@ from wagtail.admin.edit_handlers import (
     StreamFieldPanel,
     TabbedInterface,
 )
+from wagtail.api import APIField
 from wagtail.core.blocks import CharBlock, StructBlock, URLBlock
 from wagtail.core.fields import RichTextField, StreamField
 from wagtail.core.models import Orderable
@@ -22,6 +23,7 @@ from wagtail.documents.edit_handlers import DocumentChooserPanel
 from wagtail.embeds import embeds
 from wagtail.embeds.exceptions import EmbedException
 from wagtail.images import get_image_model_string
+from wagtail.images.api.fields import ImageRenditionField
 from wagtail.images.blocks import ImageChooserBlock
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.search import index
@@ -45,6 +47,12 @@ class DegreeLevel(models.Model):
 
     def __str__(self):
         return self.title
+
+
+def degree_level_serializer(*args, **kwargs):
+    """Import the serializer, without a circular import error."""
+    from rca.programmes.serializers import DegreeLevelSerializer
+    return DegreeLevelSerializer(*args, **kwargs)
 
 
 class ProgrammeType(models.Model):
@@ -510,6 +518,17 @@ class ProgrammePage(BasePage):
     )
 
     search_fields = BasePage.search_fields + []
+
+    api_fields = [
+        APIField("name"),
+        APIField("degree_level", serializer=degree_level_serializer()),
+        APIField("programme_description_title"),
+        APIField("pathway_blocks"),
+        APIField(
+            name="hero_image_square",
+            serializer=ImageRenditionField("fill-500x500", source="hero_image"),
+        ),
+    ]
 
     def get_alumni_stories(self, programme_type_legacy_slug):
         # Use the slug as prefix to the cache key

--- a/rca/programmes/serializers.py
+++ b/rca/programmes/serializers.py
@@ -1,0 +1,10 @@
+from rest_framework import serializers
+
+from rca.programmes.models import DegreeLevel
+
+
+class DegreeLevelSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = DegreeLevel
+        fields = ("id", "title")
+

--- a/rca/programmes/serializers.py
+++ b/rca/programmes/serializers.py
@@ -7,4 +7,3 @@ class DegreeLevelSerializer(serializers.ModelSerializer):
     class Meta:
         model = DegreeLevel
         fields = ("id", "title")
-

--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -91,6 +91,7 @@ INSTALLED_APPS = [
     "django.contrib.sitemaps",
     "pattern_library",
     "rca.project_styleguide.apps.ProjectStyleguideConfig",
+    "rest_framework",
 ]
 
 
@@ -657,6 +658,8 @@ PASSWORD_REQUIRED_TEMPLATE = "patterns/pages/wagtail/password_required.html"
 # Default size of the pagination used on the front-end.
 DEFAULT_PER_PAGE = 20
 
+# https://docs.wagtail.io/en/stable/advanced_topics/api/v2/configuration.html#wagtailapi-limit-max
+WAGTAILAPI_LIMIT_MAX = 50
 
 # Styleguide
 PATTERN_LIBRARY_ENABLED = env.get("PATTERN_LIBRARY_ENABLED", "false").lower() == "true"

--- a/rca/urls.py
+++ b/rca/urls.py
@@ -12,6 +12,7 @@ from wagtail.utils.urlpatterns import decorate_urlpatterns
 
 from rca.search import views as search_views
 from rca.utils.cache import get_default_cache_control_decorator
+from rca.wagtailapi.api import api_router
 
 # Private URLs are not meant to be cached.
 private_urlpatterns = [
@@ -20,6 +21,8 @@ private_urlpatterns = [
     path("documents2/", include(wagtaildocs_urls)),
     # Search cache-control headers are set on the view itself.
     path("search/", search_views.search, name="search"),
+    # Don’t use generic cache control for API endpoints.
+    path("api/v2/", api_router.urls),
 ]
 
 

--- a/rca/wagtailapi/api.py
+++ b/rca/wagtailapi/api.py
@@ -1,0 +1,6 @@
+from wagtail.api.v2 import router
+
+from rca.wagtailapi.endpoints import PagesAPIEndpoint
+
+api_router = router.WagtailAPIRouter('wagtailapi')
+api_router.register_endpoint('pages', PagesAPIEndpoint)

--- a/rca/wagtailapi/api.py
+++ b/rca/wagtailapi/api.py
@@ -2,5 +2,5 @@ from wagtail.api.v2 import router
 
 from rca.wagtailapi.endpoints import PagesAPIEndpoint
 
-api_router = router.WagtailAPIRouter('wagtailapi')
-api_router.register_endpoint('pages', PagesAPIEndpoint)
+api_router = router.WagtailAPIRouter("wagtailapi")
+api_router.register_endpoint("pages", PagesAPIEndpoint)

--- a/rca/wagtailapi/endpoints.py
+++ b/rca/wagtailapi/endpoints.py
@@ -1,0 +1,22 @@
+from wagtail.api.v2 import endpoints
+from wagtail.api.v2.filters import (
+    FieldsFilter,
+    RestrictedChildOfFilter,
+    RestrictedDescendantOfFilter,
+    SearchFilter,
+)
+from wagtail.api.v2.serializers import PageSerializer
+
+from rca.wagtailapi import filters
+
+
+class PagesAPIEndpoint(endpoints.PagesAPIEndpoint):
+    base_serializer_class = PageSerializer
+    filter_backends = [
+        # NOTE that the following filters should be listed before the SearchFilter.
+        filters.DegreeLevelFilter,
+        FieldsFilter,
+        RestrictedChildOfFilter,
+        RestrictedDescendantOfFilter,
+        SearchFilter,
+    ]

--- a/rca/wagtailapi/filters.py
+++ b/rca/wagtailapi/filters.py
@@ -1,0 +1,15 @@
+from rest_framework import filters
+
+
+class DegreeLevelFilter(filters.BaseFilterBackend):
+    """
+    Allows to filter pages by one or multiple projects
+    """
+
+    def filter_queryset(self, request, queryset, view):
+        pks = request.GET.getlist("project", [])
+
+        if pks:
+            queryset = queryset.filter(degree_level__in=pks)
+
+        return queryset


### PR DESCRIPTION
#262, but against the right target branch 😐

---

Depends on #261. See https://projects.torchbox.com/projects/rca-website-rebuild/tickets/255.

This adds a basic implementation of Wagtail’s Pages API, with textual search and filtering by `degree_level`. There will be more filters needed but they should all follow a similar implementation (the fields aren’t there yet for the other filters).