### PR TITLE
#247, #251 programmes header, contact block

### DIFF
--- a/rca/programmes/models.py
+++ b/rca/programmes/models.py
@@ -695,13 +695,6 @@ class ProgrammeIndexPage(BasePage):
 
         context["hero_colour"] = "light"
 
-        context["schools"] = [
-            "School of Architecture",
-            "School of Arts & Humanities",
-            "School of Communication",
-            "School of Design",
-        ]
-
         subpages = self.get_children().live()
         per_page = settings.DEFAULT_PER_PAGE
         page_number = request.GET.get("page")

--- a/rca/programmes/models.py
+++ b/rca/programmes/models.py
@@ -691,7 +691,7 @@ class ProgrammeIndexPage(BasePage):
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request, *args, **kwargs)
 
-        context["title_multiline"] = self.title.replace(' ', '\n')
+        context["title_multiline"] = self.title.replace(" ", "\n")
 
         context["hero_colour"] = "light"
 

--- a/rca/programmes/models.py
+++ b/rca/programmes/models.py
@@ -690,6 +690,18 @@ class ProgrammeIndexPage(BasePage):
 
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request, *args, **kwargs)
+
+        context["title_multiline"] = self.title.replace(' ', '\n')
+
+        context["hero_colour"] = "light"
+
+        context["schools"] = [
+            "School of Architecture",
+            "School of Arts & Humanities",
+            "School of Communication",
+            "School of Design",
+        ]
+
         subpages = self.get_children().live()
         per_page = settings.DEFAULT_PER_PAGE
         page_number = request.GET.get("page")

--- a/rca/project_styleguide/templates/patterns/pages/programmes/programme_index.html
+++ b/rca/project_styleguide/templates/patterns/pages/programmes/programme_index.html
@@ -1,22 +1,27 @@
 {% extends "patterns/base_page.html" %}
 {% load wagtailcore_tags wagtailimages_tags navigation_tags static %}
 
+{% block header_class %}
+    theme-light
+{% endblock %}
+
 {% block content %}
     <div class="page">
 
         <header class="page__header bg bg--dark">
-            <div class="title-area grid">
+            <div class="title-area title-area--index grid">
                 <div class="title-area__content">
-                    <h1 class="title-area__header heading heading--display-two">{{ page.title }}</h1>
-                    <p class="title-area__introduction introduction">{{ page.introduction|richtext }}</p>
+                    <h1 class="title-area__header heading heading--display-two">{{ title_multiline|linebreaksbr }}</h1>
+                </div>
+                <div class="title-area__aside">
+                    {{ page.introduction|richtext }}
                 </div>
             </div>
         </header>
 
-        <input type="search" placeholder="{{ page.search_placeholder_text }}"/>
-
         <div class="page__content">
 
+            {% comment %}
             {% if subpages %}
                 <div class="grid">
                     {% if subpages.object_list.exists %}
@@ -47,11 +52,28 @@
             {% else %}
                 {# no items on any page #}
             {% endif %}
+            {% endcomment %}
+
+            <div data-mount-programmes></div>
+
+            <section class="section section--end bg bg--light">
+                <div class="section__content">
+                    <br>
+                    <br>
+                    <br>
+                    <br>
+                    <br>
+                    <br>
+                    <br>
+                    <br>
+                    <br>
+                    <br>
+                </div>
+            </section>
 
             <section class="section bg bg--light">
-                <div class="contact-anchor" id="contact"></div>
                 <div class="section__container">
-                    {% include "patterns/organisms/contact/contact.html" with heading='Contact us' text="Get in touch if you’d like to find out more or have any questions." image=page.contact_image %}
+                    {% include "patterns/organisms/contact/contact.html" with heading='Contact us' text="If you want to register your interest about joining the RCA and receive updates from the RCA and its community." image=page.contact_image %}
                 </div>
             </section>
 

--- a/rca/project_styleguide/templates/patterns/pages/programmes/programme_index.yaml
+++ b/rca/project_styleguide/templates/patterns/pages/programmes/programme_index.yaml
@@ -2,6 +2,7 @@ context:
   title_multiline: >-
     Our
     Programmes
+  hero_colour: light
   page:
     title: Our Programmes
     introduction: <p>Experience the world&apos;s <a href="https://www.example.com/">number one</a> university for art and design.</p>

--- a/rca/project_styleguide/templates/patterns/pages/programmes/programme_index.yaml
+++ b/rca/project_styleguide/templates/patterns/pages/programmes/programme_index.yaml
@@ -1,4 +1,7 @@
 context:
+  title_multiline: >-
+    Our
+    Programmes
   page:
     title: Our Programmes
     introduction: <p>Experience the world&apos;s <a href="https://www.example.com/">number one</a> university for art and design.</p>

--- a/rca/static_src/sass/components/_heading.scss
+++ b/rca/static_src/sass/components/_heading.scss
@@ -33,8 +33,4 @@
     &--link {
         font-family: $font--secondary;
     }
-
-    &--break {
-        white-space: nowrap;
-    }
 }

--- a/rca/static_src/sass/components/_heading.scss
+++ b/rca/static_src/sass/components/_heading.scss
@@ -33,4 +33,8 @@
     &--link {
         font-family: $font--secondary;
     }
+
+    &--break {
+        white-space: nowrap;
+    }
 }

--- a/rca/static_src/sass/components/_title-area.scss
+++ b/rca/static_src/sass/components/_title-area.scss
@@ -1,4 +1,5 @@
 .title-area {
+    $root: &;
     padding-bottom: ($gutter * 3);
 
     @include media-query(medium) {
@@ -26,6 +27,27 @@
         @include media-query(large) {
             grid-column: 2 / span 3;
             top: 0;
+
+            #{$root}--index & {
+                grid-column: 2 / span 2;
+            }
         }
+    }
+
+    &__aside {
+        grid-column: 2;
+
+        @include media-query(large) {
+            $align-with-heading-second-line-lowercase: map-get(
+                    $large-font-sizes,
+                    xxxl
+                ) * ($line-height-large / 100%) + 23px;
+            grid-column: 4;
+            margin-top: $align-with-heading-second-line-lowercase;
+        }
+    }
+
+    &--index {
+        padding-top: $gutter * 9;
     }
 }

--- a/rca/static_src/sass/components/_title-area.scss
+++ b/rca/static_src/sass/components/_title-area.scss
@@ -35,15 +35,23 @@
     }
 
     &__aside {
+        // We want to align this aside text with the top of the second line of text of the heading.
+        // However there are viewports right after the "large" width where this would cause the text to overlap.
+        // In those cases, we align the text with the bottom of the line instead, so there is no overlap.
+        $xxxl-font: map-get($large-font-sizes, xxxl);
+        $heading-line-height: $xxxl-font * ($line-height-large / 100%);
+        $heading-line-2-bottom: $heading-line-height * 2;
+        // We want the text to be aligned with the top of lowercase letters on the line, so need extra space.
+        $heading-line-2-top: $heading-line-height * 1 + 23px;
         grid-column: 2;
 
         @include media-query(large) {
-            $align-with-heading-second-line-lowercase: map-get(
-                    $large-font-sizes,
-                    xxxl
-                ) * ($line-height-large / 100%) + 23px;
             grid-column: 4;
-            margin-top: $align-with-heading-second-line-lowercase;
+            margin-top: $heading-line-2-bottom;
+        }
+
+        @media only screen and (min-width: 1180px) {
+            margin-top: $heading-line-2-top;
         }
     }
 


### PR DESCRIPTION
See:

- Header: https://projects.torchbox.com/projects/rca-website-rebuild/tickets/247
- Contact us: https://projects.torchbox.com/projects/rca-website-rebuild/tickets/251

Design: https://www.figma.com/file/EWOmjORgGoHnfba7OSGmQ3ic/RCA---Phase-1-Shared?node-id=2099%3A55

The "Contact us" block is identical to the one on the programme details pages. The header wasn’t similar to other ones on the site so I created an "index" variation of `title-area`, which can hopefully be reused for other pages that have a hero-like heading without the full hero banner.