### PR TITLE
Fixing hero to be 100% height excluding any mobile nav bars

### DIFF
--- a/rca/static_src/javascript/components/actual-height.js
+++ b/rca/static_src/javascript/components/actual-height.js
@@ -1,0 +1,25 @@
+class ActualHeight {
+    constructor() {
+        this.createCustomProperty();
+        this.bindEvents();
+    }
+
+    createCustomProperty() {
+        // Work out the full height then divide by 100 to work out what 1vh should be (excluding any toolbars)
+        let vh = window.innerHeight * 0.01;
+        // Then we set the value in the --vh custom property to the root of the document
+        document.documentElement.style.setProperty('--vh', `${vh}px`);
+    }
+
+    bindEvents() {
+        window.addEventListener(
+            'resize',
+            () => {
+                this.createCustomProperty();
+            },
+            { passive: true },
+        );
+    }
+}
+
+export default ActualHeight;

--- a/rca/static_src/javascript/main.js
+++ b/rca/static_src/javascript/main.js
@@ -13,6 +13,7 @@ import VideoModal from './components/video-modal';
 import RelatedContent from './components/related-content';
 import Tabs from './components/tabs';
 import Sticky from './components/position-sticky-event';
+import ActualHeight from './components/actual-height';
 import './components/sticky-header';
 import './components/lazyload-images';
 import './components/outdated-banner';
@@ -88,4 +89,6 @@ document.addEventListener('DOMContentLoaded', function() {
     for (const sticky of document.querySelectorAll(Sticky.selector())) {
         new Sticky(sticky);
     }
+
+    new ActualHeight();
 });

--- a/rca/static_src/sass/components/_hero.scss
+++ b/rca/static_src/sass/components/_hero.scss
@@ -11,7 +11,8 @@
         position: fixed;
         left: 0;
         width: 100%;
-        height: 100vh;
+        height: 100vh; /* Fallback for browsers that do not support Custom Properties */
+        height: calc(var(--vh, 1vh) * 100);
     }
 
     &__image {
@@ -45,7 +46,8 @@
     }
 
     &__placeholder {
-        height: 100vh;
+        height: 100vh; /* Fallback for browsers that do not support Custom Properties */
+        height: calc(var(--vh, 1vh) * 100);
         pointer-events: none;
     }
 


### PR DESCRIPTION
When you have a sec could you give this a once over @chris-lawton ? Updating the hero area to be 100vh, on iOS and Mobile Chrome the menubars were overlapping the content previously.

https://projects.torchbox.com/projects/rca-website-rebuild/tickets/177
