### PR TITLE
Feature/programmes listing fuzzy matching

### DIFF
--- a/rca/programmes/models.py
+++ b/rca/programmes/models.py
@@ -538,6 +538,17 @@ class ProgrammePage(BasePage):
                 index.AutocompleteField("title", partial_match=True),
             ],
         ),
+        index.SearchField("programme_description_subtitle", partial_match=True),
+        index.AutocompleteField("programme_description_subtitle", partial_match=True),
+        index.SearchField("pathway_blocks", partial_match=True),
+        index.AutocompleteField("pathway_blocks", partial_match=True),
+        index.RelatedFields(
+            "degree_level",
+            [
+                index.SearchField("title", partial_match=True),
+                index.AutocompleteField("title", partial_match=True),
+            ],
+        ),
     ]
 
     api_fields = [

--- a/rca/programmes/models.py
+++ b/rca/programmes/models.py
@@ -531,13 +531,6 @@ class ProgrammePage(BasePage):
                 )
             ],
         ),
-        index.RelatedFields(
-            "degree_level",
-            [
-                index.SearchField("title", partial_match=True),
-                index.AutocompleteField("title", partial_match=True),
-            ],
-        ),
         index.SearchField("programme_description_subtitle", partial_match=True),
         index.AutocompleteField("programme_description_subtitle", partial_match=True),
         index.SearchField("pathway_blocks", partial_match=True),

--- a/rca/programmes/models.py
+++ b/rca/programmes/models.py
@@ -518,7 +518,27 @@ class ProgrammePage(BasePage):
         ]
     )
 
-    search_fields = BasePage.search_fields + []
+    search_fields = BasePage.search_fields + [
+        index.RelatedFields(
+            "programme_type",
+            [
+                index.RelatedFields(
+                    "programme_type",
+                    [
+                        index.SearchField("display_name", partial_match=True),
+                        index.AutocompleteField("display_name", partial_match=True),
+                    ],
+                )
+            ],
+        ),
+        index.RelatedFields(
+            "degree_level",
+            [
+                index.SearchField("title", partial_match=True),
+                index.AutocompleteField("title", partial_match=True),
+            ],
+        ),
+    ]
 
     api_fields = [
         APIField("name"),

--- a/rca/wagtailapi/endpoints.py
+++ b/rca/wagtailapi/endpoints.py
@@ -3,7 +3,6 @@ from wagtail.api.v2.filters import (
     FieldsFilter,
     RestrictedChildOfFilter,
     RestrictedDescendantOfFilter,
-    SearchFilter,
 )
 from wagtail.api.v2.serializers import PageSerializer
 
@@ -18,5 +17,5 @@ class PagesAPIEndpoint(endpoints.PagesAPIEndpoint):
         FieldsFilter,
         RestrictedChildOfFilter,
         RestrictedDescendantOfFilter,
-        SearchFilter,
+        filters.SearchFilter,
     ]

--- a/rca/wagtailapi/filters.py
+++ b/rca/wagtailapi/filters.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from rest_framework import filters
-from rest_framework.filters import BaseFilterBackend
 from wagtail.api.v2.utils import BadRequestError
 from wagtail.search.backends import get_search_backend
 from wagtail.search.backends.base import FilterFieldError, OrderByFieldError
@@ -20,7 +19,7 @@ class DegreeLevelFilter(filters.BaseFilterBackend):
         return queryset
 
 
-class SearchFilter(BaseFilterBackend):
+class SearchFilter(filters.SearchFilter):
     def filter_queryset(self, request, queryset, view):
         """
         This performs a full-text search on the result set

--- a/rca/wagtailapi/filters.py
+++ b/rca/wagtailapi/filters.py
@@ -22,7 +22,7 @@ class DegreeLevelFilter(filters.BaseFilterBackend):
 class SearchFilter(filters.SearchFilter):
     def filter_queryset(self, request, queryset, view):
         """
-        This ovverides the wagtail core api filters.SearchFilter
+        This overrides the wagtail core api filters.SearchFilter
         so we can provide autocomplet/fuzzy text matching with
         sb.autocomplete
         """

--- a/rca/wagtailapi/filters.py
+++ b/rca/wagtailapi/filters.py
@@ -1,4 +1,9 @@
+from django.conf import settings
 from rest_framework import filters
+from rest_framework.filters import BaseFilterBackend
+from wagtail.api.v2.utils import BadRequestError
+from wagtail.search.backends import get_search_backend
+from wagtail.search.backends.base import FilterFieldError, OrderByFieldError
 
 
 class DegreeLevelFilter(filters.BaseFilterBackend):
@@ -11,5 +16,51 @@ class DegreeLevelFilter(filters.BaseFilterBackend):
 
         if pks:
             queryset = queryset.filter(degree_level__in=pks)
+
+        return queryset
+
+
+class SearchFilter(BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        """
+        This performs a full-text search on the result set
+        Eg: ?search=James Joyce
+        """
+        search_enabled = getattr(settings, "WAGTAILAPI_SEARCH_ENABLED", True)
+
+        if "search" in request.GET:
+            if not search_enabled:
+                raise BadRequestError("search is disabled")
+
+            # Searching and filtering by tag at the same time is not supported
+            if getattr(queryset, "_filtered_by_tag", False):
+                raise BadRequestError(
+                    "filtering by tag with a search query is not supported"
+                )
+
+            search_query = request.GET["search"]
+            search_operator = request.GET.get("search_operator", None)
+            order_by_relevance = "order" not in request.GET
+
+            sb = get_search_backend()
+            try:
+                queryset = sb.autocomplete(
+                    search_query,
+                    queryset,
+                    operator=search_operator,
+                    order_by_relevance=order_by_relevance,
+                )
+            except FilterFieldError as e:
+                raise BadRequestError(
+                    "cannot filter by '{}' while searching (field is not indexed)".format(
+                        e.field_name
+                    )
+                )
+            except OrderByFieldError as e:
+                raise BadRequestError(
+                    "cannot order by '{}' while searching (field is not indexed)".format(
+                        e.field_name
+                    )
+                )
 
         return queryset

--- a/rca/wagtailapi/filters.py
+++ b/rca/wagtailapi/filters.py
@@ -22,8 +22,9 @@ class DegreeLevelFilter(filters.BaseFilterBackend):
 class SearchFilter(filters.SearchFilter):
     def filter_queryset(self, request, queryset, view):
         """
-        This performs a full-text search on the result set
-        Eg: ?search=James Joyce
+        This ovverides the wagtail core api filters.SearchFilter
+        so we can provide autocomplet/fuzzy text matching with
+        sb.autocomplete
         """
         search_enabled = getattr(settings, "WAGTAILAPI_SEARCH_ENABLED", True)
 


### PR DESCRIPTION
Summary:

There is to be a search for page models using a text input which will work with a few fields (TBD for now, we know a few). We will need the ability for the user to enter a few words and have the search find suitable results. So searching for `Texti` will return `Textiles` results

At the moment, degree level and programme type ar supported so test with 

http://0.0.0.0:8000/api/v2/pages/?search=diplom
http://0.0.0.0:8000/api/v2/pages/?search=MRes