### PR TITLE
Don't use a new database connection for every request

### DIFF
--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -144,7 +144,9 @@ WSGI_APPLICATION = "rca.wsgi.application"
 # https://docs.djangoproject.com/en/stable/ref/settings/#databases
 # https://github.com/kennethreitz/dj-database-url
 
-DATABASES = {"default": dj_database_url.config(default="postgres:///rca")}
+DATABASES = {
+    "default": dj_database_url.config(default="postgres:///rca", conn_max_age=600)
+}
 
 
 # Server-side cache settings. Do not confuse with front-end cache.


### PR DESCRIPTION
Looks like we have the default set which means a new db connection per request.
ref: https://my.papertrailapp.com/systems/rca-production/events?focus=1151223290744188957&selected=1151223290744188957