### PR TITLE
#250 Programmes filter by category results

### DIFF
--- a/rca/project_styleguide/templates/patterns/atoms/sprites/sprites.html
+++ b/rca/project_styleguide/templates/patterns/atoms/sprites/sprites.html
@@ -47,6 +47,11 @@
         <path stroke="#797979" d="M19.5 14.5L28 23l-8.5 8.5"></path>
     </symbol>
 
+    <symbol id="arrow-right-filled" viewBox="0 0 46 46" fill="currentColor">
+        <circle cx="23" cy="23" r="23"></circle>
+        <path d="M19.5147 14.5147L28 23L19.5147 31.4853" stroke="#ffffff"></path>
+    </symbol>
+
     <symbol id="lines" fill="none">
         <path stroke-width="2" d="M10 1h26M0 11h26"></path>
     </symbol>

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { programmeCategories } from '../../programmes.types';
+
+import Icon from '../Icon/Icon';
+
+const CategoriesPanels = ({ categories, activeCategory, applyFilter }) => {
+    return (
+        <div className="categories-panels bg bg--light">
+            {categories.map((c) => (
+                <div
+                    key={c.id}
+                    id={c.id}
+                    className="categories-panels__panel"
+                    role="tabpanel"
+                    aria-labelledby={`${c.id}-tab`}
+                    aria-expanded={c.id === activeCategory}
+                    hidden={c.id !== activeCategory}
+                >
+                    {c.items.map((i) => (
+                        <button
+                            className="categories-panels__panel-btn grid"
+                            type="button"
+                            key={i.id}
+                            onClick={() => {
+                                const params = new URLSearchParams(
+                                    window.location.search,
+                                );
+                                params.set(c.id, i.id);
+                                console.log(params);
+                                window.history.pushState(
+                                    null,
+                                    null,
+                                    `${window.location.pathname}?${params}`,
+                                );
+                                applyFilter({
+                                    [c.id]: i.id,
+                                });
+                            }}
+                        >
+                            <h3 className="heading heading--three">
+                                {i.title}
+                            </h3>
+                            <p>{i.description}</p>
+                            <Icon name="arrow-right" />
+                        </button>
+                    ))}
+                </div>
+            ))}
+        </div>
+    );
+};
+
+CategoriesPanels.propTypes = {
+    categories: programmeCategories.isRequired,
+    activeCategory: PropTypes.string.isRequired,
+};
+
+export default CategoriesPanels;

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.js
@@ -19,7 +19,11 @@ const CategoriesPanels = ({ categories, activeCategory }) => {
                     hidden={c.id !== activeCategory}
                 >
                     {c.items.map((item) => (
-                        <CategoryItem key={item.id} category={item} />
+                        <CategoryItem
+                            key={item.id}
+                            category={item}
+                            parentId={c.id}
+                        />
                     ))}
                 </div>
             ))}

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.js
@@ -5,6 +5,11 @@ import { programmeCategories } from '../../programmes.types';
 
 import CategoryItem from './CategoryItem';
 
+/**
+ * Tabs for all categories programmes can be filtered by.
+ * All tabs are rendered to the DOM so screen readers’ ARIA markup
+ * is correct.
+ */
 const CategoriesPanels = ({ categories, activeCategory }) => {
     return (
         <div className="categories-panels bg bg--light">

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 
 import { programmeCategories } from '../../programmes.types';
 
-import Icon from '../Icon/Icon';
+import CategoryItem from './CategoryItem';
 
-const CategoriesPanels = ({ categories, activeCategory, applyFilter }) => {
+const CategoriesPanels = ({ categories, activeCategory }) => {
     return (
         <div className="categories-panels bg bg--light">
             {categories.map((c) => (
@@ -18,33 +18,8 @@ const CategoriesPanels = ({ categories, activeCategory, applyFilter }) => {
                     aria-expanded={c.id === activeCategory}
                     hidden={c.id !== activeCategory}
                 >
-                    {c.items.map((i) => (
-                        <button
-                            className="categories-panels__panel-btn grid"
-                            type="button"
-                            key={i.id}
-                            onClick={() => {
-                                const params = new URLSearchParams(
-                                    window.location.search,
-                                );
-                                params.set(c.id, i.id);
-                                console.log(params);
-                                window.history.pushState(
-                                    null,
-                                    null,
-                                    `${window.location.pathname}?${params}`,
-                                );
-                                applyFilter({
-                                    [c.id]: i.id,
-                                });
-                            }}
-                        >
-                            <h3 className="heading heading--three">
-                                {i.title}
-                            </h3>
-                            <p>{i.description}</p>
-                            <Icon name="arrow-right" />
-                        </button>
+                    {c.items.map((item) => (
+                        <CategoryItem key={item.id} category={item} />
                     ))}
                 </div>
             ))}

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.scss
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.scss
@@ -1,0 +1,21 @@
+.categories-panels {
+    $root: &;
+    @include z-index(above-gridlines);
+    position: relative;
+
+    &__panel {
+        [aria-expanded='true'] {
+            @include grid-layout();
+        }
+    }
+
+    &__panel-btn {
+        border: 0;
+        background: transparent;
+        border-bottom: 1px solid $color--grid-line-light;
+
+        &[type='button'] {
+            appearance: none;
+        }
+    }
+}

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.scss
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.scss
@@ -4,6 +4,7 @@
     position: relative;
 
     &__panel {
+        // When not expanded, the panel is hidden via the HTML hidden attribute.
         [aria-expanded='true'] {
             @include grid-layout();
 

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.scss
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.scss
@@ -1,5 +1,4 @@
 .categories-panels {
-    $root: &;
     @include z-index(above-gridlines);
     position: relative;
 

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.scss
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.scss
@@ -6,6 +6,10 @@
     &__panel {
         [aria-expanded='true'] {
             @include grid-layout();
+
+            @include media-query(medium) {
+                padding-top: $gutter * 2;
+            }
         }
     }
 }

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.scss
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.scss
@@ -8,14 +8,4 @@
             @include grid-layout();
         }
     }
-
-    &__panel-btn {
-        border: 0;
-        background: transparent;
-        border-bottom: 1px solid $color--grid-line-light;
-
-        &[type='button'] {
-            appearance: none;
-        }
-    }
 }

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.test.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.test.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import CategoriesPanels from './CategoriesPanels';
+
+describe('CategoriesPanels', () => {
+    it('empty', () => {
+        expect(shallow(<CategoriesPanels categories={[]} activeCategory="" />))
+            .toMatchInlineSnapshot(`
+            <div
+              className="categories-panels bg bg--light"
+            />
+        `);
+    });
+
+    it('categories are set to active with ARIA-attributes', () => {
+        const wrapper = shallow(
+            <CategoriesPanels
+                categories={[
+                    {
+                        id: 'test',
+                        title: 'Test title',
+                        description: 'Test description',
+                        items: [],
+                    },
+                    {
+                        id: 'test2',
+                        title: 'Test title 2',
+                        description: 'Test description 2',
+                        items: [],
+                    },
+                ]}
+                activeCategory="test"
+            />,
+        );
+        expect(wrapper.find('#test').prop('aria-expanded')).toBe(true);
+        expect(wrapper.find('#test').prop('hidden')).toBe(false);
+        expect(wrapper.find('#test2').prop('aria-expanded')).toBe(false);
+        expect(wrapper.find('#test2').prop('hidden')).toBe(true);
+    });
+});

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesTablist.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesTablist.js
@@ -3,6 +3,10 @@ import PropTypes from 'prop-types';
 
 import { programmeCategories } from '../../programmes.types';
 
+/**
+ * A list of tabs, one per category. The active tab is underlined.
+ * Tabs can be moved through with the arrow keys.
+ */
 const CategoriesTablist = ({ categories, activeCategory }) => {
     return (
         <nav

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesTablist.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesTablist.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { programmeCategories } from '../../programmes.types';
+import { getCategoryURL, pushState } from '../../programmes.routes';
 
 /**
  * A list of tabs, one per category. The active tab is underlined.
@@ -17,37 +18,46 @@ const CategoriesTablist = ({ categories, activeCategory }) => {
                 Explore by
             </h2>
             <div role="tablist">
-                {categories.map((c) => (
-                    <a
-                        key={c.id}
-                        id={`${c.id}-tab`}
-                        href={`#${c.id}`}
-                        className="categories-tablist__tab body body--one"
-                        role="tab"
-                        aria-selected={c.id === activeCategory}
-                        aria-controls={c.id}
-                        onKeyDown={(e) => {
-                            const isArrowLeft = e.keyCode === 37;
-                            const isArrowRight = e.keyCode === 39;
+                {categories.map((c) => {
+                    const href = getCategoryURL(c.id);
 
-                            if (isArrowLeft && e.target.previousSibling) {
-                                window.location.hash = e.target.previousSibling.getAttribute(
-                                    'href',
-                                );
-                                e.target.previousSibling.focus();
-                            }
+                    return (
+                        <a
+                            key={c.id}
+                            id={`${c.id}-tab`}
+                            href={href}
+                            className="categories-tablist__tab body body--one"
+                            role="tab"
+                            aria-selected={c.id === activeCategory}
+                            aria-controls={c.id}
+                            onClick={pushState.bind(null, href)}
+                            onKeyDown={(e) => {
+                                const isArrowLeft = e.keyCode === 37;
+                                const isArrowRight = e.keyCode === 39;
 
-                            if (isArrowRight && e.target.nextSibling) {
-                                window.location.hash = e.target.nextSibling.getAttribute(
-                                    'href',
-                                );
-                                e.target.nextSibling.focus();
-                            }
-                        }}
-                    >
-                        {c.title}
-                    </a>
-                ))}
+                                if (isArrowLeft && e.target.previousSibling) {
+                                    pushState(
+                                        e.target.previousSibling.getAttribute(
+                                            'href',
+                                        ),
+                                    );
+                                    e.target.previousSibling.focus();
+                                }
+
+                                if (isArrowRight && e.target.nextSibling) {
+                                    pushState(
+                                        e.target.nextSibling.getAttribute(
+                                            'href',
+                                        ),
+                                    );
+                                    e.target.nextSibling.focus();
+                                }
+                            }}
+                        >
+                            {c.title}
+                        </a>
+                    );
+                })}
             </div>
         </nav>
     );

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesTablist.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesTablist.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { programmeCategories } from '../../programmes.types';
+
+const CategoriesTablist = ({ categories, activeCategory }) => {
+    return (
+        <div role="tablist" className="categories-tablist bg bg--light">
+            <h2 className="body body--two categories-tablist__heading">
+                Explore by
+            </h2>
+            <nav aria-label="Filter programmes">
+                {categories.map((c) => (
+                    <a
+                        key={c.id}
+                        id={`${c.id}-tab`}
+                        href={`#${c.id}`}
+                        className="categories-tablist__tab body body--one"
+                        role="tab"
+                        aria-selected={c.id === activeCategory}
+                    >
+                        {c.title}
+                    </a>
+                ))}
+            </nav>
+        </div>
+    );
+};
+
+CategoriesTablist.propTypes = {
+    categories: programmeCategories.isRequired,
+    activeCategory: PropTypes.string.isRequired,
+};
+
+export default CategoriesTablist;

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesTablist.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesTablist.js
@@ -5,11 +5,14 @@ import { programmeCategories } from '../../programmes.types';
 
 const CategoriesTablist = ({ categories, activeCategory }) => {
     return (
-        <div role="tablist" className="categories-tablist bg bg--light">
+        <nav
+            className="categories-tablist bg bg--light"
+            aria-label="Filter programmes"
+        >
             <h2 className="body body--two categories-tablist__heading">
                 Explore by
             </h2>
-            <nav aria-label="Filter programmes">
+            <div role="tablist">
                 {categories.map((c) => (
                     <a
                         key={c.id}
@@ -18,12 +21,31 @@ const CategoriesTablist = ({ categories, activeCategory }) => {
                         className="categories-tablist__tab body body--one"
                         role="tab"
                         aria-selected={c.id === activeCategory}
+                        aria-controls={c.id}
+                        onKeyDown={(e) => {
+                            const isArrowLeft = e.keyCode === 37;
+                            const isArrowRight = e.keyCode === 39;
+
+                            if (isArrowLeft && e.target.previousSibling) {
+                                window.location.hash = e.target.previousSibling.getAttribute(
+                                    'href',
+                                );
+                                e.target.previousSibling.focus();
+                            }
+
+                            if (isArrowRight && e.target.nextSibling) {
+                                window.location.hash = e.target.nextSibling.getAttribute(
+                                    'href',
+                                );
+                                e.target.nextSibling.focus();
+                            }
+                        }}
                     >
                         {c.title}
                     </a>
                 ))}
-            </nav>
-        </div>
+            </div>
+        </nav>
     );
 };
 

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesTablist.scss
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesTablist.scss
@@ -1,0 +1,23 @@
+.categories-tablist {
+    @include z-index(above-gridlines);
+    position: relative;
+    padding: $gutter;
+
+    &__heading {
+        color: $color--dark-grey;
+        margin-bottom: $gutter * 0.75;
+    }
+
+    &__tab {
+        color: $color--dark-grey;
+
+        &:not(:last-child) {
+            margin-right: $gutter * 1.5;
+        }
+
+        &[aria-selected='true'] {
+            color: $color--black;
+            text-decoration: underline;
+        }
+    }
+}

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesTablist.scss
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesTablist.scss
@@ -4,7 +4,7 @@
     padding: $gutter;
     padding-bottom: $gutter * 0.5;
     // Allow the tablist to overflow into the next column, as much as the contact block below.
-    margin-right: -60px;
+    margin-right: $image-offset-right;
 
     @include media-query(medium) {
         padding-bottom: $gutter;

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesTablist.scss
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesTablist.scss
@@ -27,7 +27,7 @@
         &:not(:last-child) {
             margin-right: $gutter;
 
-            @include media-query(medium) {
+            @include media-query(large) {
                 margin-right: $gutter * 1.5;
             }
         }

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesTablist.scss
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesTablist.scss
@@ -2,17 +2,34 @@
     @include z-index(above-gridlines);
     position: relative;
     padding: $gutter;
+    padding-bottom: $gutter * 0.5;
+    // Allow the tablist to overflow into the next column, as much as the contact block below.
+    margin-right: -60px;
+
+    @include media-query(medium) {
+        padding-bottom: $gutter;
+    }
 
     &__heading {
         color: $color--dark-grey;
-        margin-bottom: $gutter * 0.75;
+        margin-bottom: $gutter * 0.5;
+
+        @include media-query(medium) {
+            margin-bottom: $gutter * 0.75;
+        }
     }
 
     &__tab {
         color: $color--dark-grey;
+        font-family: $font--primary;
+        outline-width: initial;
 
         &:not(:last-child) {
-            margin-right: $gutter * 1.5;
+            margin-right: $gutter;
+
+            @include media-query(medium) {
+                margin-right: $gutter * 1.5;
+            }
         }
 
         &[aria-selected='true'] {

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoryItem.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoryItem.js
@@ -1,13 +1,14 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-import { programmeCategoryShape } from '../../programmes.types';
+import { programmeCategoryItemShape } from '../../programmes.types';
 
 import Icon from '../Icon/Icon';
 
 /**
  * A single instance from a category, leading to a filtered view of matching programmes.
  */
-const CategoryItem = ({ category }) => {
+const CategoryItem = ({ category, parentId }) => {
     const { id, title, description } = category;
 
     return (
@@ -31,7 +32,8 @@ const CategoryItem = ({ category }) => {
 };
 
 CategoryItem.propTypes = {
-    category: programmeCategoryShape.isRequired,
+    category: programmeCategoryItemShape.isRequired,
+    parentId: PropTypes.string.isRequired,
 };
 
 export default CategoryItem;

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoryItem.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoryItem.js
@@ -13,7 +13,7 @@ const CategoryItem = ({ category, parentId }) => {
 
     return (
         <div className="category-item__wrapper grid">
-            <a href={`#test-${id}`} className="category-item">
+            <a href={`#test-${parentId}-${id}`} className="category-item">
                 <h3 className="heading heading--three category-item__heading">
                     <span className="category-item__heading-inner">
                         {title}

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoryItem.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoryItem.js
@@ -4,16 +4,22 @@ import PropTypes from 'prop-types';
 import { programmeCategoryItemShape } from '../../programmes.types';
 
 import Icon from '../Icon/Icon';
+import { getCategoryItemURL, pushState } from '../../programmes.routes';
 
 /**
  * A single instance from a category, leading to a filtered view of matching programmes.
  */
 const CategoryItem = ({ category, parentId }) => {
     const { id, title, description } = category;
+    const href = getCategoryItemURL(parentId, id);
 
     return (
         <div className="category-item__wrapper grid">
-            <a href={`#test-${parentId}-${id}`} className="category-item">
+            <a
+                href={href}
+                className="category-item"
+                onClick={pushState.bind(null, href)}
+            >
                 <h3 className="heading heading--three category-item__heading">
                     <span className="category-item__heading-inner">
                         {title}

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoryItem.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoryItem.js
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { programmeCategoryShape } from '../../programmes.types';
+
+import Icon from '../Icon/Icon';
+
+const CategoryItem = ({ category }) => {
+    const { id, title, description } = category;
+
+    return (
+        <a href={`#test-${id}`} className="categories-panels__item grid">
+            <h3 className="heading heading--three categories-panels__item__heading">
+                {title}
+            </h3>
+            <p className="categories-panels__item__description">
+                {description}
+            </p>
+            <Icon
+                name="arrow-right"
+                className="categories-panels__item__icon"
+            />
+        </a>
+    );
+};
+
+CategoryItem.propTypes = {
+    category: programmeCategoryShape.isRequired,
+};
+
+export default CategoryItem;

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoryItem.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoryItem.js
@@ -4,22 +4,29 @@ import { programmeCategoryShape } from '../../programmes.types';
 
 import Icon from '../Icon/Icon';
 
+/**
+ * A single instance from a category, leading to a filtered view of matching programmes.
+ */
 const CategoryItem = ({ category }) => {
     const { id, title, description } = category;
 
     return (
-        <a href={`#test-${id}`} className="categories-panels__item grid">
-            <h3 className="heading heading--three categories-panels__item__heading">
-                {title}
-            </h3>
-            <p className="categories-panels__item__description">
-                {description}
-            </p>
-            <Icon
-                name="arrow-right"
-                className="categories-panels__item__icon"
-            />
-        </a>
+        <div className="category-item__wrapper grid">
+            <a href={`#test-${id}`} className="category-item">
+                <h3 className="heading heading--three category-item__heading">
+                    <span className="category-item__heading-inner">
+                        {title}
+                    </span>
+                </h3>
+                <div className="category-item__description">{description}</div>
+                <div className="category-item__icon-wrapper">
+                    <Icon
+                        name="arrow-right-filled"
+                        className="category-item__icon"
+                    />
+                </div>
+            </a>
+        </div>
     );
 };
 

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoryItem.scss
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoryItem.scss
@@ -11,6 +11,9 @@
     font-family: $font--primary;
     border-left: 1px solid $color--grid-line-dark;
 
+    // Bottom border, done with a pseudo element rather than a border,
+    // so it can overflow to the right and leave some space for people to scroll
+    // without accidentally clicking a link.
     &::after {
         content: '';
         grid-column: 1 / span 2;
@@ -36,6 +39,8 @@
         grid-template-columns: 1fr 1fr;
         grid-column: 2 / span 4;
         padding-top: $gutter * 1.5;
+        // Keep the left border aligned with the grid lines.
+        margin-left: -1px;
     }
 
     &__wrapper {

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoryItem.scss
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoryItem.scss
@@ -1,0 +1,38 @@
+.categories-panels__item {
+    $root: &;
+    color: inherit;
+    font-family: $font--primary;
+    border-bottom: 1px solid $color--grid-line-light;
+
+    &__heading {
+        grid-column: 1 / span 2;
+
+        @include media-query(medium) {
+            grid-column: 2 / span 2;
+        }
+    }
+
+    &__description {
+        grid-column: 1 / span 2;
+
+        @include media-query(medium) {
+            grid-column: 4 / span 1;
+        }
+    }
+
+    &__icon {
+        $size: 46px;
+        width: $size;
+        height: $size;
+
+        // Arrows only have the show-hide effect for hover-friendly browsers.
+        @media (hover: hover) {
+            opacity: 0;
+
+            #{$root}:hover &,
+            #{$root}:focus & {
+                opacity: 1;
+            }
+        }
+    }
+}

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoryItem.scss
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoryItem.scss
@@ -1,29 +1,92 @@
-.categories-panels__item {
+.category-item {
+    $padding-top-small: $gutter;
+    $padding-top-medium: $gutter * 2.5;
+    $padding-top-large: $gutter * 1.5;
     $root: &;
+    display: grid;
+    grid-column: 1 / span 2;
+    grid-template-columns: 1fr;
+    padding-top: $gutter;
     color: inherit;
     font-family: $font--primary;
-    border-bottom: 1px solid $color--grid-line-light;
+    border-left: 1px solid $color--grid-line-dark;
 
-    &__heading {
+    &::after {
+        content: '';
         grid-column: 1 / span 2;
+        height: 1px;
+        width: calc(100% + #{$gutter});
+        background-color: $color--grid-line-dark;
 
         @include media-query(medium) {
-            grid-column: 2 / span 2;
+            width: calc(100% + #{$gutter * 3});
+        }
+
+        @include media-query(large) {
+            grid-column: 1 / span 4;
+        }
+    }
+
+    @include media-query(medium) {
+        grid-template-columns: 2fr 3fr;
+        padding-top: $gutter * 2.5;
+    }
+
+    @include media-query(large) {
+        grid-template-columns: 1fr 1fr;
+        grid-column: 2 / span 4;
+        padding-top: $gutter * 1.5;
+    }
+
+    &__wrapper {
+        @include grid-layout();
+        position: relative;
+    }
+
+    &__heading {
+        grid-column: 1;
+        padding-bottom: $gutter * 0.75;
+        padding-right: $gutter;
+    }
+
+    &__heading-inner {
+        #{$root}:hover &,
+        #{$root}:focus & {
+            text-decoration: underline;
         }
     }
 
     &__description {
-        grid-column: 1 / span 2;
+        grid-column: 1;
+        padding-top: 0;
+        padding-bottom: $gutter * 2;
 
         @include media-query(medium) {
-            grid-column: 4 / span 1;
+            grid-column: 2;
+            padding-right: $gutter * 6;
+            padding-bottom: $gutter * 1.5;
         }
     }
 
     &__icon {
-        $size: 46px;
-        width: $size;
-        height: $size;
+        width: 24px;
+        height: 24px;
+        position: absolute;
+        top: $padding-top-small;
+        right: $gutter;
+
+        @include media-query(medium) {
+            width: 36px;
+            height: 36px;
+            top: $padding-top-medium;
+            right: $gutter * 3;
+        }
+
+        @include media-query(large) {
+            width: 46px;
+            height: 46px;
+            top: $padding-top-large;
+        }
 
         // Arrows only have the show-hide effect for hover-friendly browsers.
         @media (hover: hover) {

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/ProgrammesCategories.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/ProgrammesCategories.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { useLocation } from 'react-use';
 
@@ -13,9 +12,17 @@ import CategoriesPanels from './CategoriesPanels';
  * A list of programmes matching a search or filter.
  * The list auto-magically appears when matches are found.
  */
-const ProgrammesCategories = ({ categories, applyFilter }) => {
+const ProgrammesCategories = ({ categories }) => {
     const loc = useLocation();
-    const activeCategory = loc.hash.replace('#', '') || categories[0].id;
+    const params = new URLSearchParams(loc.search);
+    const activeCategory = params.get('category') || categories[0].id;
+    const activeItem = params.get('value');
+    const activeSearch = params.get('search');
+
+    if (activeItem || activeSearch) {
+        return null;
+    }
+
     return (
         <div>
             <div className="section section--opposite-notch bg bg--dark">
@@ -31,7 +38,6 @@ const ProgrammesCategories = ({ categories, applyFilter }) => {
             <CategoriesPanels
                 categories={categories}
                 activeCategory={activeCategory}
-                applyFilter={applyFilter}
             />
         </div>
     );
@@ -39,7 +45,6 @@ const ProgrammesCategories = ({ categories, applyFilter }) => {
 
 ProgrammesCategories.propTypes = {
     categories: programmeCategories.isRequired,
-    applyFilter: PropTypes.func.isRequired,
 };
 
 const mapDispatchToProps = {

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/ProgrammesCategories.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/ProgrammesCategories.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { useLocation } from 'react-use';
+
+import { programmeCategories } from '../../programmes.types';
+import { searchProgrammes } from '../../programmes.slice';
+
+import CategoriesTablist from './CategoriesTablist';
+import CategoriesPanels from './CategoriesPanels';
+
+/**
+ * A list of programmes matching a search or filter.
+ * The list auto-magically appears when matches are found.
+ */
+const ProgrammesCategories = ({ categories, applyFilter }) => {
+    const loc = useLocation();
+    const activeCategory = loc.hash.replace('#', '') || categories[0].id;
+    return (
+        <div>
+            <div className="section section--opposite-notch bg bg--dark">
+                <div className="section__notch section__notch--opposite">
+                    <div className="section__notch-fill section__notch-fill--second-col">
+                        <CategoriesTablist
+                            categories={categories}
+                            activeCategory={activeCategory}
+                        />
+                    </div>
+                </div>
+            </div>
+            <CategoriesPanels
+                categories={categories}
+                activeCategory={activeCategory}
+                applyFilter={applyFilter}
+            />
+        </div>
+    );
+};
+
+ProgrammesCategories.propTypes = {
+    categories: programmeCategories.isRequired,
+    applyFilter: PropTypes.func.isRequired,
+};
+
+const mapDispatchToProps = {
+    applyFilter: searchProgrammes.bind(null, ''),
+};
+
+export default connect(null, mapDispatchToProps)(ProgrammesCategories);

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/ProgrammesCategories.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/ProgrammesCategories.js
@@ -20,7 +20,7 @@ const ProgrammesCategories = ({ categories, applyFilter }) => {
         <div>
             <div className="section section--opposite-notch bg bg--dark">
                 <div className="section__notch section__notch--opposite">
-                    <div className="section__notch-fill section__notch-fill--second-col">
+                    <div className="section__notch-fill section__notch-fill--content-height section__notch-fill--first-col section__notch-fill--second-col@medium">
                         <CategoriesTablist
                             categories={categories}
                             activeCategory={activeCategory}

--- a/rca/static_src/javascript/programmes/components/ProgrammesExplorer.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesExplorer.js
@@ -1,20 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { programmeCategories } from '../programmes.types';
+
 import SearchForm from './SearchForm';
 import ProgrammesResults from './ProgrammesResults/ProgrammesResults';
+import ProgrammesCategories from './ProgrammesCategories/ProgrammesCategories';
 
-const ProgrammesExplorer = ({ searchLabel }) => {
+const ProgrammesExplorer = ({ searchLabel, categories }) => {
     return (
-        <div>
+        <>
             <SearchForm label={searchLabel} />
+            <ProgrammesCategories categories={categories} />
             <ProgrammesResults />
-        </div>
+        </>
     );
 };
 
 ProgrammesExplorer.propTypes = {
     searchLabel: PropTypes.string,
+    categories: programmeCategories.isRequired,
 };
 
 ProgrammesExplorer.defaultProps = {

--- a/rca/static_src/javascript/programmes/components/ProgrammesExplorer.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesExplorer.js
@@ -12,7 +12,7 @@ const ProgrammesExplorer = ({ searchLabel, categories }) => {
         <>
             <SearchForm label={searchLabel} />
             <ProgrammesCategories categories={categories} />
-            <ProgrammesResults />
+            <ProgrammesResults categories={categories} />
         </>
     );
 };

--- a/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammesResults.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammesResults.js
@@ -30,9 +30,8 @@ const ProgrammesResults = ({ programmes, hasActiveSearch }) => {
     const [activeProgramme, setActiveProgramme] = useState(null);
     const loc = useLocation();
     const hasActiveFilter = loc.search.length > 0;
-    console.log(hasActiveFilter, hasActiveSearch);
 
-    if (!hasActiveFilter) {
+    if (!hasActiveFilter && !hasActiveSearch) {
         return null;
     }
 

--- a/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammesResults.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammesResults.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { useLocation } from 'react-use';
 
 import { programmePageShape } from '../../programmes.types';
 
@@ -27,7 +28,11 @@ const getResultsCount = (count) => {
  */
 const ProgrammesResults = ({ programmes, hasActiveSearch }) => {
     const [activeProgramme, setActiveProgramme] = useState(null);
-    if (!hasActiveSearch) {
+    const loc = useLocation();
+    const hasActiveFilter = loc.search.length > 0;
+    console.log(hasActiveFilter, hasActiveSearch);
+
+    if (!hasActiveFilter) {
         return null;
     }
 

--- a/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammesResults.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammesResults.js
@@ -28,7 +28,10 @@ const getResultsStatus = (
         const activeItem = activeCategory.items.find(
             (i) => `${i.id}` === categoryValue,
         );
-        return `${activeCategory.title}: ${activeItem.title}`;
+
+        if (activeItem) {
+            return `${activeCategory.title}: ${activeItem.title}`;
+        }
     }
 
     switch (count) {

--- a/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammesResults.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammesResults.js
@@ -41,14 +41,16 @@ const ProgrammesResults = ({
     const hasActiveFilter = category && value;
 
     useEffect(() => {
-        filterProgrammes({ [category]: value });
-        const mount = document.querySelector(
-            '[data-mount-programmes-explorer]',
-        );
-        if (mount) {
-            mount.scrollIntoView({ behavior: 'smooth' });
+        if (hasActiveFilter) {
+            filterProgrammes({ [category]: value });
+            const mount = document.querySelector(
+                '[data-mount-programmes-explorer]',
+            );
+            if (mount) {
+                mount.scrollIntoView({ behavior: 'smooth' });
+            }
         }
-    }, [filterProgrammes, category, value]);
+    }, [filterProgrammes, hasActiveFilter, category, value]);
 
     if (!hasActiveFilter && !hasActiveSearch) {
         return null;

--- a/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammesResults.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammesResults.js
@@ -3,13 +3,34 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { useLocation } from 'react-use';
 
-import { programmePageShape } from '../../programmes.types';
+import {
+    programmePageShape,
+    programmeCategories,
+} from '../../programmes.types';
 import { searchProgrammes } from '../../programmes.slice';
 
 import Icon from '../Icon/Icon';
 import ProgrammeTeaser from './ProgrammeTeaser';
 
-const getResultsCount = (count) => {
+const getResultsStatus = (
+    isLoading,
+    categories,
+    category,
+    categoryValue,
+    count,
+) => {
+    if (isLoading) {
+        return 'Loading…';
+    }
+
+    const activeCategory = categories.find((c) => c.id === category);
+    if (activeCategory) {
+        const activeItem = activeCategory.items.find(
+            (i) => `${i.id}` === categoryValue,
+        );
+        return `${activeCategory.title}: ${activeItem.title}`;
+    }
+
     switch (count) {
         case 0: {
             return 'No results match your search';
@@ -28,6 +49,7 @@ const getResultsCount = (count) => {
  * The list auto-magically appears when matches are found.
  */
 const ProgrammesResults = ({
+    categories,
     programmes,
     hasActiveSearch,
     isLoading,
@@ -56,7 +78,6 @@ const ProgrammesResults = ({
         return null;
     }
 
-    const count = getResultsCount(programmes.length);
     const theme = hasActiveFilter ? 'light' : 'dark';
     return (
         <>
@@ -80,7 +101,13 @@ const ProgrammesResults = ({
                         className="heading heading--five programmes-results__status"
                         role="alert"
                     >
-                        {isLoading ? 'Loading…' : count}
+                        {getResultsStatus(
+                            isLoading,
+                            categories,
+                            category,
+                            value,
+                            programmes.length,
+                        )}
                     </p>
                 </div>
                 {programmes.length === 0 ? null : (
@@ -142,6 +169,7 @@ const ProgrammesResults = ({
 };
 
 ProgrammesResults.propTypes = {
+    categories: programmeCategories.isRequired,
     programmes: PropTypes.arrayOf(programmePageShape).isRequired,
     hasActiveSearch: PropTypes.bool.isRequired,
     isLoading: PropTypes.bool.isRequired,

--- a/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammesResults.scss
+++ b/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammesResults.scss
@@ -6,7 +6,7 @@
         padding-top: $gutter * 3;
     }
 
-    &__count {
+    &__status {
         grid-column: 1 / span 2;
         margin-bottom: $gutter * 1.5;
 

--- a/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammesResults.scss
+++ b/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammesResults.scss
@@ -77,7 +77,7 @@
         display: none;
         grid-column: 4 / span 2;
         // Matching the contact block’s so the images are aligned with its image.
-        margin-right: -60px;
+        margin-right: $image-offset-right;
 
         @include media-query(large) {
             display: block;

--- a/rca/static_src/javascript/programmes/components/SearchForm.js
+++ b/rca/static_src/javascript/programmes/components/SearchForm.js
@@ -10,6 +10,7 @@ import {
 } from '../programmes.slice';
 
 import Icon from './Icon/Icon';
+import { pushState, getIndexURL } from '../programmes.routes';
 
 /**
  * A search form for programmes, visually only appearing as a single field.
@@ -67,7 +68,7 @@ const SearchForm = ({
                             className="search__button button body body--two"
                             type="button"
                             onClick={(e) => {
-                                e.preventDefault();
+                                pushState(getIndexURL(), e);
                                 clearQuery();
                             }}
                         >

--- a/rca/static_src/javascript/programmes/programmes.routes.js
+++ b/rca/static_src/javascript/programmes/programmes.routes.js
@@ -1,0 +1,44 @@
+const getParams = () => new URLSearchParams(window.location.search);
+const getURL = (params) => {
+    const hasParams = params.keys().length > 0;
+    return `${window.location.pathname}${hasParams ? '?' : ''}${params}`;
+};
+
+export const getIndexURL = () => {
+    const params = getParams();
+    params.delete('search');
+    params.delete('category');
+    params.delete('value');
+    return getURL(params);
+};
+
+export const getCategoryURL = (category) => {
+    const params = getParams();
+    params.delete('search');
+    params.set('category', category);
+    params.delete('value');
+    return getURL(params);
+};
+
+export const getCategoryItemURL = (category, item) => {
+    const params = getParams();
+    params.delete('search');
+    params.set('category', category);
+    params.set('value', item);
+    return getURL(params);
+};
+
+export const getSearchURL = (search) => {
+    const params = getParams();
+    params.delete('category');
+    params.delete('value');
+    params.set('search', search);
+    return getURL(params);
+};
+
+export const pushState = (href, e = null) => {
+    if (e) {
+        e.preventDefault();
+    }
+    window.history.pushState(null, null, href);
+};

--- a/rca/static_src/javascript/programmes/programmes.routes.js
+++ b/rca/static_src/javascript/programmes/programmes.routes.js
@@ -1,7 +1,8 @@
 const getParams = () => new URLSearchParams(window.location.search);
 const getURL = (params) => {
-    const hasParams = params.keys().length > 0;
-    return `${window.location.pathname}${hasParams ? '?' : ''}${params}`;
+    const queryString = params.toString();
+    const hasQuery = queryString !== '';
+    return `${window.location.pathname}${hasQuery ? '?' : ''}${queryString}`;
 };
 
 export const getIndexURL = () => {

--- a/rca/static_src/javascript/programmes/programmes.slice.js
+++ b/rca/static_src/javascript/programmes/programmes.slice.js
@@ -28,6 +28,7 @@ const { reducer, actions } = createSlice({
         loadResultsStart: (state) => {
             state.ui = { ...initialState.ui };
             state.ui.isLoading = true;
+            state.results = initialState.results;
         },
 
         loadResultsSuccess: (state, { payload }) => {
@@ -39,6 +40,7 @@ const { reducer, actions } = createSlice({
         loadResultsError: (state, { payload }) => {
             state.ui = { ...initialState.ui };
             state.ui.error = payload;
+            state.results = initialState.results;
         },
     },
 });

--- a/rca/static_src/javascript/programmes/programmes.slice.js
+++ b/rca/static_src/javascript/programmes/programmes.slice.js
@@ -1,6 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 import { getProgrammes } from './programmes.api';
+import { pushState, getSearchURL } from './programmes.routes';
 
 const initialState = {
     searchQuery: '',
@@ -54,6 +55,10 @@ export const { setSearchQuery, clearSearchQuery } = actions;
 export const searchProgrammes = (searchQuery, filters = {}) => {
     return (dispatch) => {
         dispatch(actions.loadResultsStart());
+
+        if (searchQuery) {
+            pushState(getSearchURL(searchQuery));
+        }
 
         getProgrammes({
             query: searchQuery,

--- a/rca/static_src/sass/abstracts/_variables.scss
+++ b/rca/static_src/sass/abstracts/_variables.scss
@@ -117,6 +117,9 @@ $gutter: $grid;
 // Wrappers
 $site-width: 1440px;
 
+// Offsets
+$image-offset-right: -($gutter * 3);
+
 // --------------------------------- Transitions --------------------------------------
 
 $transition: 0.25s ease-out;

--- a/rca/static_src/sass/components/_contact.scss
+++ b/rca/static_src/sass/components/_contact.scss
@@ -66,7 +66,7 @@
         position: relative;
         grid-column: 4 / span 2;
         margin-top: -($gutter * 14);
-        margin-right: -($gutter * 3);
+        margin-right: $image-offset-right;
         display: none;
 
         #{$root}__image {

--- a/rca/static_src/sass/components/_image.scss
+++ b/rca/static_src/sass/components/_image.scss
@@ -12,7 +12,7 @@
         margin-right: -$gutter;
 
         @include media-query(medium) {
-            margin-right: -($gutter * 3);
+            margin-right: $image-offset-right;
         }
 
         @include media-query(large) {

--- a/rca/static_src/sass/components/_section.scss
+++ b/rca/static_src/sass/components/_section.scss
@@ -170,6 +170,14 @@
             height: $notch-height-large;
         }
 
+        &--content-height {
+            height: initial;
+        }
+
+        #{$root}__notch--opposite & {
+            grid-column: 1 / span 2;
+        }
+
         &::before {
             display: block;
             position: absolute;
@@ -200,6 +208,22 @@
         &--second-col {
             #{$root}__notch--opposite & {
                 grid-column: 2 / span 1;
+            }
+
+            @include media-query(large) {
+                grid-column: 1 / span 2;
+
+                #{$root}__notch--opposite & {
+                    grid-column: 4 / span 2;
+                }
+            }
+        }
+
+        &--second-col\@medium {
+            @include media-query(medium) {
+                #{$root}__notch--opposite & {
+                    grid-column: 2 / span 1;
+                }
             }
 
             @include media-query(large) {

--- a/rca/static_src/sass/main.scss
+++ b/rca/static_src/sass/main.scss
@@ -85,6 +85,8 @@
 
 @import '../javascript/programmes/components/ProgrammesResults/ProgrammesResults';
 @import '../javascript/programmes/components/ProgrammesResults/ProgrammeTeaser';
+@import '../javascript/programmes/components/ProgrammesCategories/CategoriesTablist';
+@import '../javascript/programmes/components/ProgrammesCategories/CategoriesPanels';
 
 // Layout
 @import 'layout/footer';

--- a/rca/static_src/sass/main.scss
+++ b/rca/static_src/sass/main.scss
@@ -87,6 +87,7 @@
 @import '../javascript/programmes/components/ProgrammesResults/ProgrammeTeaser';
 @import '../javascript/programmes/components/ProgrammesCategories/CategoriesTablist';
 @import '../javascript/programmes/components/ProgrammesCategories/CategoriesPanels';
+@import '../javascript/programmes/components/ProgrammesCategories/CategoryItem';
 
 // Layout
 @import 'layout/footer';


### PR DESCRIPTION
Depends on #278. There isn’t many changes here so this will be much easier to review once #278 is merged. See https://projects.torchbox.com/projects/rca-website-rebuild/tickets/250.

Design: https://www.figma.com/file/EWOmjORgGoHnfba7OSGmQ3ic/RCA---Phase-1-Shared?node-id=1810%3A2

---

This reuses the programmes’ search existing results view, with a light theme, to display results from categories.

There is still more work to be done for the transitions between those different views in a separate ticket.