### PR TITLE
Feature/100 98 updates 2020

### DIFF
--- a/rca/api_content/content.py
+++ b/rca/api_content/content.py
@@ -1,10 +1,10 @@
 import logging
-import re
 from datetime import datetime
 
 import requests
 from django.conf import settings
 from django.http.request import QueryDict
+from django.utils.html import strip_tags
 from django.utils.text import Truncator
 
 """
@@ -12,12 +12,6 @@ Static methods for adding content from the live RCA api
 """
 
 logger = logging.getLogger(__name__)
-
-
-def remove_html_tags(text):
-    """Remove html tags from a string"""
-    clean = re.compile("<.*?>")
-    return re.sub(clean, "", text)
 
 
 def ranged_date_format(date, date_to):
@@ -94,11 +88,11 @@ def parse_items_to_list(data, type):
             _item["description"] = date
         # Instead of date... alumni stories will just the body/intro text
         if type == "alumni_stories_standard_page":
-            _item["description"] = data["intro"]
+            _item["description"] = Truncator(strip_tags(data["intro"])).words(25)
             _item["type"] = "Alumni story"
             date = data["meta"]["first_published_at"]
         if type == "alumni_stories_blog_page":
-            _item["description"] = Truncator(remove_html_tags(data["body"])).words(25)
+            _item["description"] = Truncator(strip_tags(data["body"])).words(25)
             _item["type"] = "Alumni story"
             date = data["meta"]["first_published_at"]
 

--- a/rca/api_content/content.py
+++ b/rca/api_content/content.py
@@ -1,14 +1,35 @@
 import logging
+import re
 from datetime import datetime
 
 import requests
+from django.conf import settings
 from django.http.request import QueryDict
+from django.utils.text import Truncator
 
 """
 Static methods for adding content from the live RCA api
 """
 
 logger = logging.getLogger(__name__)
+
+
+def remove_html_tags(text):
+    """Remove html tags from a string"""
+    clean = re.compile("<.*?>")
+    return re.sub(clean, "", text)
+
+
+def ranged_date_format(date, date_to):
+    """ Method to format dates that have 'to' and 'from' values """
+    if int(date[5:7]) is int(date_to[5:7]):
+        date_to = datetime.strptime(date_to, "%Y-%m-%d")
+        date = datetime.strptime(date, "%Y-%m-%d")
+        return date.strftime("%-d") + " - " + date_to.strftime("%-d %B %Y")
+    else:
+        date_to = datetime.strptime(date_to, "%Y-%m-%d")
+        date = datetime.strptime(date, "%Y-%m-%d")
+        return date.strftime("%-d %B") + " - " + date_to.strftime("%-d %B %Y")
 
 
 class CantPullFromRcaApi(Exception):
@@ -21,12 +42,19 @@ def parse_items_to_list(data, type):
     for item in data["items"]:
         _item = {}
         if type == "News":
-            detail = item["meta"]["detail_url"] + "?fields=_,date,feed_image"
+            detail = item["meta"]["detail_url"] + "?fields=_,date,social_image"
         if type == "Event":
-            detail = item["meta"]["detail_url"] + "?fields=_,dates_times,feed_image"
-        if type == "Alumni stories":
-            detail = item["meta"]["detail_url"] + "?fields=_,feed_image,intro"
-
+            detail = item["meta"]["detail_url"] + "?fields=_,dates_times,social_image"
+        if type == "alumni_stories_standard_page":
+            detail = (
+                item["meta"]["detail_url"]
+                + "?fields=_,first_published_at,social_image,intro"
+            )
+        if type == "alumni_stories_blog_page":
+            detail = (
+                item["meta"]["detail_url"]
+                + "?fields=_,first_published_at,social_image,body"
+            )
         try:
             response = requests.get(url=detail)
             response.raise_for_status()
@@ -36,29 +64,45 @@ def parse_items_to_list(data, type):
             raise CantPullFromRcaApi(error_text)
 
         data = response.json()
-        if "feed_image" in data:
-            feed_image = data["feed_image"]["meta"]["detail_url"]
-            feed_image = requests.get(url=feed_image)
-            feed_image = feed_image.json()
-            feed_image_url = feed_image["rca2019_feed_image"]["url"]
-            feed_image_small_url = feed_image["rca2019_feed_image_small"]["url"]
-            _item["image"] = feed_image_url
-            _item["image_small"] = feed_image_small_url
-            _item["image_alt"] = feed_image["alt"]
+        if "social_image" in data and data["social_image"]:
+            social_image = data["social_image"]["meta"]["detail_url"]
+            social_image = requests.get(url=social_image)
+            social_image = social_image.json()
+            if "url" in social_image["rca2019_feed_image"]:
+                social_image_url = social_image["rca2019_feed_image"]["url"]
+                social_image_small_url = social_image["rca2019_feed_image_small"]["url"]
+                _item["image"] = social_image_url
+                _item["image_small"] = social_image_small_url
+                _item["image_alt"] = social_image["alt"]
         date = False
         if type == "News":
             date = data["date"]
+            _item["type"] = type
         if type == "Event":
             date = data["dates_times"][0]["date_from"]
-        if type == "Alumni stories":
-            _item["description"] = data["intro"]
+            # Some events need to show 'from' and 'to' dates,
+            # E.G, 7-8 January 2020
+            date_to = data["dates_times"][0]["date_to"]
+            if date_to:
+                _item["formatted_date"] = ranged_date_format(date, date_to)
+            _item["type"] = type
         if date:
+            date = date[:10]  # just the year,month and day.... TODO cleaner
+            _item["original_date"] = date
             date = datetime.strptime(date, "%Y-%m-%d")
             date = date.strftime("%-d %B %Y")
             _item["description"] = date
+        # Instead of date... alumni stories will just the body/intro text
+        if type == "alumni_stories_standard_page":
+            _item["description"] = data["intro"]
+            _item["type"] = "Alumni story"
+            date = data["meta"]["first_published_at"]
+        if type == "alumni_stories_blog_page":
+            _item["description"] = Truncator(remove_html_tags(data["body"])).words(25)
+            _item["type"] = "Alumni story"
+            date = data["meta"]["first_published_at"]
 
         _item["title"] = item["title"]
-        _item["type"] = type
         _item["link"] = item["meta"]["html_url"]
         items.append(_item)
 
@@ -66,21 +110,31 @@ def parse_items_to_list(data, type):
 
 
 def pull_news_and_events(programme_type_slug=None):
-    # Get the latest 2 news items and 1 event item tagged
-    # with the programme type taxonomy, if there are no events, use 3 news
+    # 'News' is actually a mixture of NewItem and RcaBlogPage models.
+    # So pull 3 of both from the API and order them by the date field.
+    # Then select how many we need depending on the events content.
+
+    # First get the Events
     query = QueryDict(mutable=True)
-    query.update({"limit": 1, "event_date_from": True, "type": "rca.EventItem"})
+    query.update(
+        {
+            "type": "rca.EventItem",
+            "limit": 1,
+            "event_date_from": True,
+            "show_on_homepage": "true",
+        }
+    )
 
     if programme_type_slug:
         query.update({"rp": programme_type_slug})
 
     query = query.urlencode()
-    events_url = f"https://rca.ac.uk/api/v2/pages/?{query}"
+    events_url = f"{settings.API_CONTENT_BASE_URL}/api/v2/pages/?{query}"
 
-    # By default, get 3 news items but if we pull events, get 2
+    # By default, work with 3 news items but if we pull events, get 2
+    # so we end up with 2 x News/Blog and 1 x Event.
     news_items_to_get = 3
 
-    # First get the events
     events_data = []
     try:
         response = requests.get(url=events_url)
@@ -97,13 +151,49 @@ def pull_news_and_events(programme_type_slug=None):
             news_items_to_get = 2
             events_data = parse_items_to_list(data, "Event")
 
-    # News
+    # News and Blogs
+    # Pull 3 Blog items
     query = QueryDict(mutable=True)
-    query.update({"limit": news_items_to_get, "order": "-date", "type": "rca.NewsItem"})
+    query.update(
+        {
+            "limit": "3",
+            "order": "-date",
+            "type": "rca.RcaBlogPage",
+            "show_on_homepage": "true",
+            "tags_not": "alumni-story",
+        }
+    )
+    if programme_type_slug:
+        query.update({"rp": programme_type_slug})
+
+    query = query.urlencode()
+    blog_url = f"{settings.API_CONTENT_BASE_URL}/api/v2/pages/?{query}"
+    try:
+        response = requests.get(url=blog_url)
+        response.raise_for_status()
+        logger.info("Pulling Blogs from API")
+    except requests.exceptions.HTTPError:
+        error_text = "Error occured when fetching Blog data"
+        logger.exception(error_text)
+        raise CantPullFromRcaApi(error_text)
+    else:
+        data = response.json()
+        blog_data = parse_items_to_list(data, "News")
+
+    # Pull 3 News items
+    query = QueryDict(mutable=True)
+    query.update(
+        {
+            "limit": 3,
+            "order": "-date",
+            "type": "rca.NewsItem",
+            "show_on_homepage": "true",
+        }
+    )
     if programme_type_slug:
         query.update({"rp": programme_type_slug})
     query = query.urlencode()
-    news_url = f"https://rca.ac.uk/api/v2/pages/?{query}"
+    news_url = f"{settings.API_CONTENT_BASE_URL}/api/v2/pages/?{query}"
     news_data = []
 
     try:
@@ -118,11 +208,21 @@ def pull_news_and_events(programme_type_slug=None):
         data = response.json()
         news_data = parse_items_to_list(data, "News")
 
-    return news_data + events_data
+    news_and_blog_data = news_data + blog_data
+    # Sort by the date
+    news_and_blog_data.sort(key=lambda x: x["original_date"])
+    news_and_blog_data.reverse()
+    # Slice for how many items we want to get depending on the Events pulled.
+    news_and_blog_data = news_and_blog_data[:news_items_to_get]
+
+    return news_and_blog_data + events_data
 
 
 def pull_alumni_stories(programme_type_slug=None):
+    # 'Alumni stories' are a mixture of StandardPage and RcaBlogPage models.
+    # that are tagged with 'alumni-stories...
 
+    # Pull 3 StandardPage items
     query = QueryDict(mutable=True)
     query.update(
         {
@@ -130,13 +230,14 @@ def pull_alumni_stories(programme_type_slug=None):
             "order": "-first_published_at",
             "type": "rca.StandardPage",
             "tags": "alumni-story",
+            "show_on_homepage": "true",
         }
     )
+    alumni_stories_standrad_page_data = []
     if programme_type_slug:
         query.update({"rp": programme_type_slug})
     query = query.urlencode()
-    url = f"https://rca.ac.uk/api/v2/pages/?{query}"
-
+    url = f"{settings.API_CONTENT_BASE_URL}/api/v2/pages/?{query}"
     try:
         response = requests.get(url=url)
         response.raise_for_status()
@@ -147,6 +248,40 @@ def pull_alumni_stories(programme_type_slug=None):
         raise CantPullFromRcaApi(error_text)
     else:
         data = response.json()
-        # Should this parse also be in a better try/catch?
-        alumni_stories_data = parse_items_to_list(data, "Alumni stories")
-        return alumni_stories_data
+        alumni_stories_standrad_page_data = parse_items_to_list(
+            data, "alumni_stories_standard_page"
+        )
+
+    # Pull 3 BlogPage items
+    query = QueryDict(mutable=True)
+    query.update(
+        {
+            "limit": 3,
+            "order": "-first_published_at",
+            "type": "rca.RcaBlogPage",
+            "tags": "alumni-story",
+            "show_on_homepage": "true",
+        }
+    )
+    if programme_type_slug:
+        query.update({"rp": programme_type_slug})
+    query = query.urlencode()
+    url = f"{settings.API_CONTENT_BASE_URL}/api/v2/pages/?{query}"
+    try:
+        response = requests.get(url=url)
+        response.raise_for_status()
+        logger.info("pulling Alumni Stories from API")
+    except requests.exceptions.HTTPError:
+        error_text = "Error occured when fetching alumni stories data"
+        logger.exception(error_text)
+        raise CantPullFromRcaApi(error_text)
+    else:
+        data = response.json()
+        alumni_stories_blog_page_data = parse_items_to_list(
+            data, "alumni_stories_blog_page"
+        )
+
+    alumni_stories_data = (
+        alumni_stories_blog_page_data + alumni_stories_standrad_page_data
+    )
+    return alumni_stories_data

--- a/rca/home/models.py
+++ b/rca/home/models.py
@@ -218,4 +218,7 @@ class HomePage(BasePage):
             "background_image"
         ).first()
 
+        context["news_and_events"] = self.get_news_and_events()
+        context["alumni_stories"] = self.get_alumni_stories()
+
         return context

--- a/rca/programmes/models.py
+++ b/rca/programmes/models.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 
 from django.conf import settings
-from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import models
@@ -27,7 +26,6 @@ from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.search import index
 from wagtail.snippets.edit_handlers import SnippetChooserPanel
 
-from rca.api_content import content
 from rca.home.models import HERO_COLOUR_CHOICES, LIGHT_TEXT_ON_DARK_IMAGE
 from rca.utils.blocks import (
     AccordionBlockWithTitle,
@@ -510,36 +508,6 @@ class ProgrammePage(BasePage):
     )
 
     search_fields = BasePage.search_fields + []
-
-    def get_alumni_stories(self, programme_type_legacy_slug):
-        # Use the slug as prefix to the cache key
-        cache_key = f"{programme_type_legacy_slug}_programme_latest_alumni_stories"
-        stories_data = cache.get(cache_key)
-        if stories_data is None:
-            try:
-                stories_data = content.pull_alumni_stories(programme_type_legacy_slug)
-            except content.CantPullFromRcaApi:
-                return []
-            else:
-                cache.set(cache_key, stories_data, settings.API_CONTENT_CACHE_TIMEOUT)
-        return stories_data
-
-    def get_news_and_events(self, programme_type_legacy_slug):
-        # Use the slug as prefix to the cache key
-        cache_key = f"{programme_type_legacy_slug}_programme_latest_news_and_events"
-        news_and_events_data = cache.get(cache_key)
-        if news_and_events_data is None:
-            try:
-                news_and_events_data = content.pull_news_and_events(
-                    programme_type_legacy_slug
-                )
-            except content.CantPullFromRcaApi:
-                return []
-            else:
-                cache.set(
-                    cache_key, news_and_events_data, settings.API_CONTENT_CACHE_TIMEOUT
-                )
-        return news_and_events_data
 
     def clean(self):
         errors = defaultdict(list)

--- a/rca/project_styleguide/templates/patterns/molecules/card/card_api_content.html
+++ b/rca/project_styleguide/templates/patterns/molecules/card/card_api_content.html
@@ -15,7 +15,9 @@
                         {{ item.title }}
                     {% if item.link %}</a>{% endif %}
                 </h3>
-                <div class="card__description">{{ item.description|richtext }}</div>
+                <div class="card__description">
+                {% firstof item.formatted_date item.description|richtext %}
+                </div>
             </div>
         </div>
     </div>

--- a/rca/project_styleguide/templates/patterns/pages/home/home_page.html
+++ b/rca/project_styleguide/templates/patterns/pages/home/home_page.html
@@ -45,7 +45,6 @@
                     </section>
 
             {% endif %}
-            {% comment %}
                 {% if alumni_stories %}
                     <section class="section section--top-space bg bg--dark">
 
@@ -61,7 +60,6 @@
 
                     </section>
                 {% endif %}
-            {% endcomment %}
 
             {% if stats_block %}
                 {% include "patterns/organisms/stat-block/stat-block.html" %}
@@ -82,7 +80,6 @@
                 </section>
             {% endif %}
 
-            {% comment %}
                 <section class="section section--end bg bg--dark">
 
                     <div class="section__notch section__notch--top">
@@ -104,7 +101,6 @@
                     </div>
 
                 </section>
-            {% endcomment %}
 
         </div>
 

--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -679,6 +679,6 @@ if "RECAPTCHA_PUBLIC_KEY" in env:
     NOCAPTCHA = True
 
 # Variable for how long to cache content from the current api for
-API_CONTENT_CACHE_TIMEOUT = 60 * 60 * 24
+API_CONTENT_CACHE_TIMEOUT = int(env.get("API_CONTENT_CACHE_TIMEOUT", 60 * 60 * 24))
 API_CONTENT_BASE_URL = "https://rca-verdant-staging.herokuapp.com"
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 2000

--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -680,4 +680,5 @@ if "RECAPTCHA_PUBLIC_KEY" in env:
 
 # Variable for how long to cache content from the current api for
 API_CONTENT_CACHE_TIMEOUT = 60 * 60 * 24
+API_CONTENT_BASE_URL = "https://rca-verdant-staging.herokuapp.com"
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 2000


### PR DESCRIPTION
Updates to the homepage api content feed:

- [x] Only pull content that has the field 'Show on homepage' ticked. (We will need to add the `show on homepage` field to the BlogPost model.
- [x] Update the image pulled to use the 'Social image' field rather than 'feed image'
- [x] Update Alumni stories content to also pull blog posts tagged with `alumni-stories`
- [x] As alumni stories are published as blog posts, how do we make sure they don't appear in the news & events feed? do we need to add an exclusion to the news & events feed - "do not include items tagged with alumni-stories"
- [x] For alumni stories, we agreed that the intro would be pulled from the first paragraph of blog posts since we don't have an intro field
- [x] Update news fields to match the field spec 
- [x] Update alumni story fields to match the field spec 
- [x] Update event  fields to match the field spec 
- [x] if no upcoming event, the 3 most recent news stories should display (as long as they satisfy other criteria)
- [x] For news & events date, this should display as "9 February 2020" or "7–12 February 2020" for events

Accompanying verdant legacy changes are on [feature/api-updates-for-new-site](https://github.com/torchbox/verdant-rca/blob/feature/api-updates-for-new-site/django-verdant/rca/models.py)
Draft pr for the legacy updates: https://github.com/torchbox/verdant-rca/pull/243