### PR TITLE
Adds a manual cache clearing mechanism for the api content feeds

### DIFF
--- a/rca/api_content/templates/api_content/api_content_admin.html
+++ b/rca/api_content/templates/api_content/api_content_admin.html
@@ -1,0 +1,32 @@
+{% extends "wagtailadmin/base.html" %}
+{% load wagtailadmin_tags static i18n %}
+{% block titletag %}{% trans "Dashboard" %}{% endblock %}
+{% block bodyclass %}homepage{% endblock %}
+
+
+{% block content %}
+    <script>
+    function clear_cache() {
+        $.get('/admin/api-cache/clear/', function (data) {
+            $("#cache_clear_button").removeClass("button-longrunning-active")
+            $("#cache_clear_button").prop("disabled", false);
+            $('.content').prepend('<div class="messages"><ul><li class="success">Success! API feed cache has been cleared</li></ul></div>')
+        });
+    }
+    </script>
+    <header class="merged nice-padding">
+        <div class="row row-flush">
+            <div class="col12">
+                <h1>Content feed settings</h1>
+            </div>
+        </div>
+    </header>
+    <div class="nice-padding">
+        <div class="help-block help-info">
+        <p>Some pages on the webstie use a content feed from the legacy API, for example, the News and Events section on the bottom of the homepage . This data is stored in the cache and automatically expires after one day.</p>
+        <p>You can manually clear the cache of the content feed here, this will cause new content to be pulled from the legacy API</p>
+        </div>
+        <button id="cache_clear_button" class="button button-longrunning" onclick="clear_cache()" id="button-arbitrarily-bigger"><span class="icon icon-spinner"></span>Clear API content feed cache</button>
+    </div>
+
+{% endblock %}

--- a/rca/api_content/views.py
+++ b/rca/api_content/views.py
@@ -1,0 +1,13 @@
+from django.core.cache import cache
+from django.http import HttpResponseRedirect
+from django.views.generic import TemplateView
+
+
+class ApiContentCacheSettings(TemplateView):
+    template_name = "api_content/api_content_admin.html"
+
+
+def ApiContentCacheClear(request):
+    cache_keys = ["latest_news_and_events", "latest_alumni_stories"]
+    cache.delete_many(cache_keys)
+    return HttpResponseRedirect("/admin/api-cache/")

--- a/rca/api_content/wagtail_hooks.py
+++ b/rca/api_content/wagtail_hooks.py
@@ -1,4 +1,7 @@
 from django.conf.urls import url
+from django.urls import reverse
+from django.utils.translation import ugettext_lazy as _
+from wagtail.admin.menu import MenuItem
 from wagtail.core import hooks
 
 from .views import ApiContentCacheClear, ApiContentCacheSettings
@@ -7,6 +10,18 @@ from .views import ApiContentCacheClear, ApiContentCacheSettings
 @hooks.register("register_admin_urls")
 def urlconf_time():
     return [
-        url(r"^api-cache/", ApiContentCacheSettings.as_view()),
+        url(
+            r"^api-cache/", ApiContentCacheSettings.as_view(), name="api-cache-settings"
+        ),
         url(r"^api-cache/clear/", ApiContentCacheClear),
     ]
+
+
+@hooks.register("register_settings_menu_item")
+def register_api_content_settings_menu_item():
+    return MenuItem(
+        _("API content settings"),
+        reverse("api-cache-settings"),
+        classnames="icon icon-cog",
+        order=1000,
+    )

--- a/rca/api_content/wagtail_hooks.py
+++ b/rca/api_content/wagtail_hooks.py
@@ -1,0 +1,12 @@
+from django.conf.urls import url
+from wagtail.core import hooks
+
+from .views import ApiContentCacheClear, ApiContentCacheSettings
+
+
+@hooks.register("register_admin_urls")
+def urlconf_time():
+    return [
+        url(r"^api-cache/", ApiContentCacheSettings.as_view()),
+        url(r"^api-cache/clear/", ApiContentCacheClear),
+    ]


### PR DESCRIPTION
### Context
The homepage will feature content pulled in from the legacy API. The pulled content is [stored in the cache for 24h](https://github.com/torchbox/rca-wagtail-2019/blob/staging/rca/settings/base.py#L686)

### Changes
There is a requirement to force clear this cache so this PR adds a new section in the admin UI where this can be done. If this is implemented I will recommend we set the cache on production for the pulled content to be larger than 24h.