### PR TITLE
#262 Changes based on programmes listing feedback

### DIFF
--- a/rca/programmes/models.py
+++ b/rca/programmes/models.py
@@ -787,7 +787,6 @@ class ProgrammeIndexPage(BasePage):
             }
             for i in ProgrammeType.objects.all()
         ]
-        programme_types_title = ProgrammeType._meta.verbose_name.capitalize()
         subjects = [
             {
                 "title": i.title,
@@ -797,21 +796,16 @@ class ProgrammeIndexPage(BasePage):
             }
             for i in Subject.objects.all().order_by("title")
         ]
-        subjects_title = Subject._meta.verbose_name.capitalize()
         schools = [
             {"title": i.title, "id": i.id, "description": i.description, "slug": i.slug}
             for i in SchoolsAndResearchPage.objects.live()
         ]
         filters = [
-            {
-                "id": "programme_type",
-                "title": programme_types_title,
-                "items": programme_types,
-            },
-            {"id": "subjects", "title": subjects_title, "items": subjects},
+            {"id": "subjects", "title": "Subject", "items": subjects},
+            {"id": "programme_type", "title": "Type", "items": programme_types},
             {
                 "id": "related_schools_and_research_pages",
-                "title": "School",
+                "title": "Schools & centres",
                 "items": schools,
             },
         ]

--- a/rca/project_styleguide/templates/patterns/pages/programmes/programme_index.html
+++ b/rca/project_styleguide/templates/patterns/pages/programmes/programme_index.html
@@ -5,6 +5,11 @@
     theme-light
 {% endblock %}
 
+{% block meta_tags %}
+    <link rel="canonical" href="{{ page.get_site.root_url }}{% pageurl self %}" />
+    {{ block.super }}
+{% endblock %}
+
 {% block content %}
     <div class="page">
 

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoryItem.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoryItem.js
@@ -10,8 +10,8 @@ import { getCategoryItemURL, pushState } from '../../programmes.routes';
  * A single instance from a category, leading to a filtered view of matching programmes.
  */
 const CategoryItem = ({ category, parentId }) => {
-    const { id, title, description } = category;
-    const href = getCategoryItemURL(parentId, id);
+    const { id, title, description, slug } = category;
+    const href = getCategoryItemURL(parentId, id, slug);
 
     return (
         <div className="category-item__wrapper grid">

--- a/rca/static_src/javascript/programmes/components/ProgrammesExplorer.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesExplorer.js
@@ -17,7 +17,8 @@ const ProgrammesExplorer = ({ searchLabel, categories }) => {
     const loc = useLocation();
     const params = new URLSearchParams(loc.search);
     const activeCategory = params.get('category') || categories[0].id;
-    const activeValue = params.get('value');
+    const filterValue = params.get('value') || '';
+    const activeValue = filterValue.split('-')[0];
     const hasActiveCategoryFilter = !!activeValue;
     const searchQuery = params.get('search') || '';
     const hasActiveSearch = !!searchQuery;

--- a/rca/static_src/javascript/programmes/programmes.routes.js
+++ b/rca/static_src/javascript/programmes/programmes.routes.js
@@ -21,11 +21,11 @@ export const getCategoryURL = (category) => {
     return getURL(params);
 };
 
-export const getCategoryItemURL = (category, item) => {
+export const getCategoryItemURL = (category, item, slug) => {
     const params = getParams();
     params.delete('search');
     params.set('category', category);
-    params.set('value', item);
+    params.set('value', `${item}-${slug}`);
     return getURL(params);
 };
 

--- a/rca/static_src/javascript/programmes/programmes.types.js
+++ b/rca/static_src/javascript/programmes/programmes.types.js
@@ -47,6 +47,7 @@ export const programmeCategoryItem = {
     id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
     title: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
+    slug: PropTypes.string.isRequired,
 };
 
 export const programmeCategoryItemShape = PropTypes.shape(


### PR DESCRIPTION
See https://projects.torchbox.com/projects/rca-website-rebuild/tickets/262. I did most of the small styles changes directly on `feature/programmes-listing`, but wouldn’t mind feedback on a few bigger pieces:

- Adding a canonical to the page – not part of the feedback but I noticed I forgot to add it.
- Adding the slugs in the URL, based on the new fields from @kevinhowbrook. This was easier than I thought!
- Reordering and renaming the categories. This was marked as "Post-launch", but is very little work so might as well do it at the same time.