### PR TITLE
Adds content feed via api to the homepage (rebased)

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,4 +5,4 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 
-known_third_party = dj_database_url,django,gunicorn,invoke,modelcluster,pattern_library,raven,requests,taggit,wagtail,wagtailcaptcha
+known_third_party = bs4,dj_database_url,django,gunicorn,invoke,modelcluster,pattern_library,raven,requests,taggit,wagtail,wagtailcaptcha

--- a/rca/api_content/content.py
+++ b/rca/api_content/content.py
@@ -2,6 +2,8 @@ import logging
 from datetime import datetime
 
 import requests
+from bs4 import BeautifulSoup
+from django.conf import settings
 from django.http.request import QueryDict
 
 """
@@ -9,6 +11,28 @@ Static methods for adding content from the live RCA api
 """
 
 logger = logging.getLogger(__name__)
+
+
+def format_first_paragraph(input_text, tag):
+    soup = BeautifulSoup(input_text, "html.parser")
+    text = soup.find_all("h5")
+    if text:
+        return text[0].text
+    else:
+        text = ""
+    return text
+
+
+def ranged_date_format(date, date_to):
+    """ Method to format dates that have 'to' and 'from' values """
+    if int(date[5:7]) is int(date_to[5:7]):
+        date_to = datetime.strptime(date_to, "%Y-%m-%d")
+        date = datetime.strptime(date, "%Y-%m-%d")
+        return date.strftime("%-d") + " - " + date_to.strftime("%-d %B %Y")
+    else:
+        date_to = datetime.strptime(date_to, "%Y-%m-%d")
+        date = datetime.strptime(date, "%Y-%m-%d")
+        return date.strftime("%-d %B") + " - " + date_to.strftime("%-d %B %Y")
 
 
 class CantPullFromRcaApi(Exception):
@@ -21,12 +45,19 @@ def parse_items_to_list(data, type):
     for item in data["items"]:
         _item = {}
         if type == "News":
-            detail = item["meta"]["detail_url"] + "?fields=_,date,feed_image"
+            detail = item["meta"]["detail_url"] + "?fields=_,date,social_image"
         if type == "Event":
-            detail = item["meta"]["detail_url"] + "?fields=_,dates_times,feed_image"
-        if type == "Alumni stories":
-            detail = item["meta"]["detail_url"] + "?fields=_,feed_image,intro"
-
+            detail = item["meta"]["detail_url"] + "?fields=_,dates_times,social_image"
+        if type == "alumni_stories_standard_page":
+            detail = (
+                item["meta"]["detail_url"]
+                + "?fields=_,first_published_at,social_image,intro"
+            )
+        if type == "alumni_stories_blog_page":
+            detail = (
+                item["meta"]["detail_url"]
+                + "?fields=_,first_published_at,social_image,body"
+            )
         try:
             response = requests.get(url=detail)
             response.raise_for_status()
@@ -36,29 +67,45 @@ def parse_items_to_list(data, type):
             raise CantPullFromRcaApi(error_text)
 
         data = response.json()
-        if "feed_image" in data:
-            feed_image = data["feed_image"]["meta"]["detail_url"]
-            feed_image = requests.get(url=feed_image)
-            feed_image = feed_image.json()
-            feed_image_url = feed_image["rca2019_feed_image"]["url"]
-            feed_image_small_url = feed_image["rca2019_feed_image_small"]["url"]
-            _item["image"] = feed_image_url
-            _item["image_small"] = feed_image_small_url
-            _item["image_alt"] = feed_image["alt"]
+        if "social_image" in data and data["social_image"]:
+            social_image = data["social_image"]["meta"]["detail_url"]
+            social_image = requests.get(url=social_image)
+            social_image = social_image.json()
+            if "url" in social_image["rca2019_feed_image"]:
+                social_image_url = social_image["rca2019_feed_image"]["url"]
+                social_image_small_url = social_image["rca2019_feed_image_small"]["url"]
+                _item["image"] = social_image_url
+                _item["image_small"] = social_image_small_url
+                _item["image_alt"] = social_image["alt"]
         date = False
         if type == "News":
             date = data["date"]
+            _item["type"] = type
         if type == "Event":
             date = data["dates_times"][0]["date_from"]
-        if type == "Alumni stories":
-            _item["description"] = data["intro"]
+            # Some events need to show 'from' and 'to' dates,
+            # E.G, 7-8 January 2020
+            date_to = data["dates_times"][0]["date_to"]
+            if date_to:
+                _item["formatted_date"] = ranged_date_format(date, date_to)
+            _item["type"] = type
         if date:
+            date = date[:10]  # just the year,month and day
+            _item["original_date"] = date
             date = datetime.strptime(date, "%Y-%m-%d")
             date = date.strftime("%-d %B %Y")
             _item["description"] = date
+        # Instead of date... alumni stories will just the body/intro text
+        if type == "alumni_stories_standard_page":
+            _item["description"] = data["intro"]
+            _item["type"] = "Alumni story"
+            date = data["meta"]["first_published_at"]
+        if type == "alumni_stories_blog_page":
+            _item["description"] = format_first_paragraph(data["body"], "h5")
+            _item["type"] = "Alumni story"
+            date = data["meta"]["first_published_at"]
 
         _item["title"] = item["title"]
-        _item["type"] = type
         _item["link"] = item["meta"]["html_url"]
         items.append(_item)
 
@@ -66,21 +113,31 @@ def parse_items_to_list(data, type):
 
 
 def pull_news_and_events(programme_type_slug=None):
-    # Get the latest 2 news items and 1 event item tagged
-    # with the programme type taxonomy, if there are no events, use 3 news
+    # 'News' is actually a mixture of NewItem and RcaBlogPage models.
+    # So pull 3 of both from the API and order them by the date field.
+    # Then select how many we need depending on the events content.
+
+    # First get the Events
     query = QueryDict(mutable=True)
-    query.update({"limit": 1, "event_date_from": True, "type": "rca.EventItem"})
+    query.update(
+        {
+            "type": "rca.EventItem",
+            "limit": 1,
+            "event_date_from": True,
+            "show_on_homepage": "true",
+        }
+    )
 
     if programme_type_slug:
         query.update({"rp": programme_type_slug})
 
     query = query.urlencode()
-    events_url = f"https://rca.ac.uk/api/v2/pages/?{query}"
+    events_url = f"{settings.API_CONTENT_BASE_URL}/api/v2/pages/?{query}"
 
-    # By default, get 3 news items but if we pull events, get 2
+    # By default, work with 3 news items but if we pull events, get 2
+    # so we end up with 2 x News/Blog and 1 x Event.
     news_items_to_get = 3
 
-    # First get the events
     events_data = []
     try:
         response = requests.get(url=events_url)
@@ -97,13 +154,49 @@ def pull_news_and_events(programme_type_slug=None):
             news_items_to_get = 2
             events_data = parse_items_to_list(data, "Event")
 
-    # News
+    # News and Blogs
+    # Pull 3 Blog items
     query = QueryDict(mutable=True)
-    query.update({"limit": news_items_to_get, "order": "-date", "type": "rca.NewsItem"})
+    query.update(
+        {
+            "limit": "3",
+            "order": "-date",
+            "type": "rca.RcaBlogPage",
+            "show_on_homepage": "true",
+            "tags_not": "Alumni_Story",
+        }
+    )
+    if programme_type_slug:
+        query.update({"rp": programme_type_slug})
+
+    query = query.urlencode()
+    blog_url = f"{settings.API_CONTENT_BASE_URL}/api/v2/pages/?{query}"
+    try:
+        response = requests.get(url=blog_url)
+        response.raise_for_status()
+        logger.info("Pulling Blogs from API")
+    except requests.exceptions.HTTPError:
+        error_text = "Error occured when fetching Blog data"
+        logger.exception(error_text)
+        raise CantPullFromRcaApi(error_text)
+    else:
+        data = response.json()
+        blog_data = parse_items_to_list(data, "News")
+
+    # Pull 3 News items
+    query = QueryDict(mutable=True)
+    query.update(
+        {
+            "limit": 3,
+            "order": "-date",
+            "type": "rca.NewsItem",
+            "show_on_homepage": "true",
+        }
+    )
     if programme_type_slug:
         query.update({"rp": programme_type_slug})
     query = query.urlencode()
-    news_url = f"https://rca.ac.uk/api/v2/pages/?{query}"
+    news_url = f"{settings.API_CONTENT_BASE_URL}/api/v2/pages/?{query}"
     news_data = []
 
     try:
@@ -118,25 +211,36 @@ def pull_news_and_events(programme_type_slug=None):
         data = response.json()
         news_data = parse_items_to_list(data, "News")
 
-    return news_data + events_data
+    news_and_blog_data = news_data + blog_data
+    # Sort by the date
+    news_and_blog_data.sort(key=lambda x: x["original_date"])
+    news_and_blog_data.reverse()
+    # Slice for how many items we want to get depending on the Events pulled.
+    news_and_blog_data = news_and_blog_data[:news_items_to_get]
+
+    return news_and_blog_data + events_data
 
 
 def pull_alumni_stories(programme_type_slug=None):
+    # 'Alumni stories' are a mixture of StandardPage and RcaBlogPage models.
+    # that are tagged with 'alumni-stories...
 
+    # Pull 3 StandardPage items
     query = QueryDict(mutable=True)
     query.update(
         {
             "limit": 3,
             "order": "-first_published_at",
             "type": "rca.StandardPage",
-            "tags": "alumni-story",
+            "tags": "Alumni_Story",
+            "show_on_homepage": "true",
         }
     )
+    alumni_stories_standrad_page_data = []
     if programme_type_slug:
         query.update({"rp": programme_type_slug})
     query = query.urlencode()
-    url = f"https://rca.ac.uk/api/v2/pages/?{query}"
-
+    url = f"{settings.API_CONTENT_BASE_URL}/api/v2/pages/?{query}"
     try:
         response = requests.get(url=url)
         response.raise_for_status()
@@ -147,6 +251,40 @@ def pull_alumni_stories(programme_type_slug=None):
         raise CantPullFromRcaApi(error_text)
     else:
         data = response.json()
-        # Should this parse also be in a better try/catch?
-        alumni_stories_data = parse_items_to_list(data, "Alumni stories")
-        return alumni_stories_data
+        alumni_stories_standrad_page_data = parse_items_to_list(
+            data, "alumni_stories_standard_page"
+        )
+
+    # Pull 3 BlogPage items
+    query = QueryDict(mutable=True)
+    query.update(
+        {
+            "limit": 3,
+            "order": "-first_published_at",
+            "type": "rca.RcaBlogPage",
+            "tags": "Alumni_Story",
+            "show_on_homepage": "true",
+        }
+    )
+    if programme_type_slug:
+        query.update({"rp": programme_type_slug})
+    query = query.urlencode()
+    url = f"{settings.API_CONTENT_BASE_URL}/api/v2/pages/?{query}"
+    try:
+        response = requests.get(url=url)
+        response.raise_for_status()
+        logger.info("pulling Alumni Stories from API")
+    except requests.exceptions.HTTPError:
+        error_text = "Error occured when fetching alumni stories data"
+        logger.exception(error_text)
+        raise CantPullFromRcaApi(error_text)
+    else:
+        data = response.json()
+        alumni_stories_blog_page_data = parse_items_to_list(
+            data, "alumni_stories_blog_page"
+        )
+
+    alumni_stories_data = (
+        alumni_stories_blog_page_data + alumni_stories_standrad_page_data
+    )
+    return alumni_stories_data

--- a/rca/home/models.py
+++ b/rca/home/models.py
@@ -218,4 +218,7 @@ class HomePage(BasePage):
             "background_image"
         ).first()
 
+        context["news_and_events"] = self.get_news_and_events()
+        context["alumni_stories"] = self.get_alumni_stories()
+
         return context

--- a/rca/project_styleguide/templates/patterns/organisms/news/news_api_content.html
+++ b/rca/project_styleguide/templates/patterns/organisms/news/news_api_content.html
@@ -16,7 +16,7 @@
         {% endif %}
 
         {% if forloop.last %}
-                <a class="news__view-all link link--secondary link--link body body--two" href="/studying-at-the-rca/the-rca-experience/">
+                <a class="news__view-all link link--primary link--link body body--two" href="/news-and-events/">
                     <span class="link__label">See all news & events</span>
                     <svg class="link__icon" width="12" height="8"><use xlink:href="#arrow"></use></svg>
                 </a>

--- a/rca/project_styleguide/templates/patterns/pages/home/home_page.html
+++ b/rca/project_styleguide/templates/patterns/pages/home/home_page.html
@@ -19,7 +19,7 @@
                 <section class="section section--top-space-large bg bg--dark">
 
                     <div class="proposition-statement grid">
-                        <div class="proposition-statement__introduction">{{ page.strapline }}</div>
+                        <h1 class="proposition-statement__introduction">{{ page.strapline }}</h1>
                         {% if page.strapline_cta_url and page.strapline_cta_text %}
                             <a href="{{ page.strapline_cta_url }}" class="proposition-statement__link link link--primary link--link link--book">
                                 <span class="link__label">{{ page.strapline_cta_text }}</span>
@@ -45,7 +45,6 @@
                     </section>
 
             {% endif %}
-            {% comment %}
                 {% if alumni_stories %}
                     <section class="section section--top-space bg bg--dark">
 
@@ -61,14 +60,13 @@
 
                     </section>
                 {% endif %}
-            {% endcomment %}
 
             {% if stats_block %}
                 {% include "patterns/organisms/stat-block/stat-block.html" %}
             {% endif %}
 
             {% if partnerships_block %}
-                <section class="section section--end section--top-space bg bg--dark">
+                <section class="section section--end section--top-space bg bg--light">
                     <div class="partnerships">
                         <div class="partnerships__header grid">
                             <h2 class="partnerships__heading heading heading--one">{{ partnerships_block.title }}</h2>
@@ -82,7 +80,6 @@
                 </section>
             {% endif %}
 
-            {% comment %}
                 <section class="section section--end bg bg--dark">
 
                     <div class="section__notch section__notch--top">
@@ -93,7 +90,7 @@
                     <div class="section__container">
 
                         <header class="section__header grid">
-                            <h3 class="section__heading section__heading--primary heading heading--two">News & events</h3>
+                            <h3 class="section__heading section__heading--primary heading heading--two">What&#39;s happening at the RCA</h3>
                         </header>
                         {% if news_and_events %}
                             <div class="section__content grid">
@@ -104,7 +101,6 @@
                     </div>
 
                 </section>
-            {% endcomment %}
 
         </div>
 

--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -58,6 +58,7 @@ INSTALLED_APPS = [
     "rca.images",
     "rca.navigation",
     "rca.programmes",
+    "rca.schools",
     "rca.search",
     "rca.standardpages",
     "rca.users",
@@ -78,6 +79,7 @@ INSTALLED_APPS = [
     "wagtail.search",
     "wagtail.admin",
     "wagtail.core",
+    "wagtailorderable",
     "modelcluster",
     "taggit",
     "captcha",
@@ -91,8 +93,8 @@ INSTALLED_APPS = [
     "django.contrib.sitemaps",
     "pattern_library",
     "rca.project_styleguide.apps.ProjectStyleguideConfig",
+    "rest_framework",
 ]
-
 
 # Middleware classes
 # https://docs.djangoproject.com/en/stable/ref/settings/#middleware
@@ -570,6 +572,15 @@ if "RECAPTCHA_PUBLIC_KEY" in env and "RECAPTCHA_PRIVATE_KEY" in env:
     RECAPTCHA_PRIVATE_KEY = env["RECAPTCHA_PRIVATE_KEY"]
 
 
+# Django REST framework settings
+# Disable basic auth to API: we have a middleware for basic auth
+# that handles all requests.
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework.authentication.SessionAuthentication",
+    )
+}
+
 # Basic authentication settings
 # These are settings to configure the third-party library:
 # https://gitlab.com/tmkn/django-basic-auth-ip-whitelist
@@ -592,6 +603,7 @@ if env.get("BASIC_AUTH_ENABLED", "false").lower().strip() == "true":
         "193.227.244.0/23",
         "2001:41c8:103::/48",
         "5.153.227.112/28",
+        "193.227.244.54",
         # RCA networks
         # Kensington
         "194.80.196.128/25",
@@ -659,6 +671,12 @@ PASSWORD_REQUIRED_TEMPLATE = "patterns/pages/wagtail/password_required.html"
 # Default size of the pagination used on the front-end.
 DEFAULT_PER_PAGE = 20
 
+# https://docs.wagtail.io/en/stable/advanced_topics/api/v2/configuration.html#wagtailapi-limit-max
+WAGTAILAPI_LIMIT_MAX = 50
+
+# https://docs.wagtail.io/en/stable/advanced_topics/api/v2/configuration.html#wagtailapi-limit-max
+WAGTAILAPI_LIMIT_MAX = 50
+
 
 # Styleguide
 PATTERN_LIBRARY_ENABLED = env.get("PATTERN_LIBRARY_ENABLED", "false").lower() == "true"
@@ -678,6 +696,8 @@ if "RECAPTCHA_PUBLIC_KEY" in env:
     RECAPTCHA_PUBLIC_KEY = env["RECAPTCHA_PUBLIC_KEY"]
     NOCAPTCHA = True
 
+
 # Variable for how long to cache content from the current api for
-API_CONTENT_CACHE_TIMEOUT = 60 * 60 * 24
+API_CONTENT_CACHE_TIMEOUT = int(env.get("API_CONTENT_CACHE_TIMEOUT", 60 * 60 * 24))
+API_CONTENT_BASE_URL = "https://rca-verdant-staging.herokuapp.com"
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 2000

--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -78,7 +78,6 @@ INSTALLED_APPS = [
     "wagtail.search",
     "wagtail.admin",
     "wagtail.core",
-    "wagtailorderable",
     "modelcluster",
     "taggit",
     "captcha",

--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -697,6 +697,6 @@ if "RECAPTCHA_PUBLIC_KEY" in env:
 
 # Variable for how long to cache content from the current api for
 API_CONTENT_CACHE_TIMEOUT = int(env.get("API_CONTENT_CACHE_TIMEOUT", 60 * 60 * 24))
-# The API url to pull content from for the homepage, see rca.api_contne.contne
+# The API url to pull content from for the homepage, see rca.api_content.content
 API_CONTENT_BASE_URL = env.get("API_CONTENT_BASE_URL", "https://rca.ac.uk")
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 2000

--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -697,5 +697,6 @@ if "RECAPTCHA_PUBLIC_KEY" in env:
 
 # Variable for how long to cache content from the current api for
 API_CONTENT_CACHE_TIMEOUT = int(env.get("API_CONTENT_CACHE_TIMEOUT", 60 * 60 * 24))
-API_CONTENT_BASE_URL = "https://rca-verdant-staging.herokuapp.com"
+# The API url to pull content from for the homepage, see rca.api_contne.contne
+API_CONTENT_BASE_URL = env.get("API_CONTENT_BASE_URL", "https://rca.ac.uk")
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 2000

--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -58,7 +58,6 @@ INSTALLED_APPS = [
     "rca.images",
     "rca.navigation",
     "rca.programmes",
-    "rca.schools",
     "rca.search",
     "rca.standardpages",
     "rca.users",

--- a/rca/static_src/sass/components/_section.scss
+++ b/rca/static_src/sass/components/_section.scss
@@ -134,20 +134,20 @@
         .bg--stat-block & {
             &:first-child {
                 #{$root}__notch-fill {
-                    background-color: $color--white; // Changed from black to white for API module removal
+                    background-color: $color--black; // Changed from black to white for API module removal
 
                     &::before {
-                        background-color: $color--white; // Changed from black to white for API module removal
+                        background-color: $color--black; // Changed from black to white for API module removal
                     }
                 }
             }
 
             &:last-child {
                 #{$root}__notch-fill {
-                    background-color: $color--black; // Changed from white to black for API module removal
+                    background-color: $color--white; // Changed from white to black for API module removal
 
                     &::before {
-                        background-color: $color--black; // Changed from white to black for API module removal
+                        background-color: $color--white; // Changed from white to black for API module removal
                     }
                 }
             }


### PR DESCRIPTION
This is rebased because it was a very old feature.

Updates to the homepage api content feed:

- [x] Only pull content that has the field 'Show on homepage' ticked. (We will need to add the `show on homepage` field to the BlogPost model.
- [x] Update the image pulled to use the 'Social image' field rather than 'feed image'
- [x] Update Alumni stories content to also pull blog posts tagged with `alumni-stories`
- [x] As alumni stories are published as blog posts, how do we make sure they don't appear in the news & events feed? do we need to add an exclusion to the news & events feed - "do not include items tagged with alumni-stories"
- [x] For alumni stories, we agreed that the intro would be pulled from the first paragraph of blog posts since we don't have an intro field
- [x] Update news fields to match the field spec 
- [x] Update alumni story fields to match the field spec 
- [x] Update event  fields to match the field spec 
- [x] if no upcoming event, the 3 most recent news stories should display (as long as they satisfy other criteria)
- [x] For news & events date, this should display as "9 February 2020" or "7–12 February 2020" for events
- [x] rebase on master, might need to revert https://github.com/torchbox/rca-wagtail-2019/pull/308/commits/231efcc07f1807cc2338618546be1ee4bb85dba0
- [x] Merge accompanying verdant legacy changes are on [feature/api-updates-for-new-site](https://github.com/torchbox/verdant-rca/blob/feature/api-updates-for-new-site/django-verdant/rca/models.py) - pr here https://github.com/torchbox/verdant-rca/pull/243
- [x] Before merging and deploying, set the cache timeout for the homepage feed to 15mins
- [x] PR was reviewed for staging https://github.com/torchbox/rca-wagtail-2019/pull/141