### PR TITLE
Limit requests to the legacy site to stop the app crashing

### DIFF
--- a/rca/api_content/content.py
+++ b/rca/api_content/content.py
@@ -5,6 +5,7 @@ import requests
 from bs4 import BeautifulSoup
 from django.conf import settings
 from django.http.request import QueryDict
+from requests.exceptions import ConnectionError, HTTPError, Timeout
 
 """
 Static methods for adding content from the live RCA api
@@ -39,9 +40,37 @@ class CantPullFromRcaApi(Exception):
     pass
 
 
+def fetch_data(url):
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+    except Timeout:
+        logger.exception(f"Timeout error occurred when fetching data from {url}")
+        raise CantPullFromRcaApi(
+            "Error occured when fetching further detail data from {url}"
+        )
+    except (HTTPError, ConnectionError):
+        logger.exception(
+            "HTTP/ConnectionError occured when fetching further detail data from {url}"
+        )
+        raise CantPullFromRcaApi(
+            "Error occured when fetching further detail data from {url}"
+        )
+    except Exception:
+        logger.exception(
+            f"Exception occured when fetching further detail data from {url}"
+        )
+        raise CantPullFromRcaApi(
+            "Error occured when fetching further detail data from {url}"
+        )
+    else:
+        return response.json()
+
+
 def parse_items_to_list(data, type):
     items = []
-
+    if not data:
+        return []
     for item in data["items"]:
         _item = {}
         if type == "News":
@@ -58,18 +87,14 @@ def parse_items_to_list(data, type):
                 item["meta"]["detail_url"]
                 + "?fields=_,first_published_at,social_image,body"
             )
-        try:
-            response = requests.get(url=detail, timeout=5)
-            response.raise_for_status()
-        except requests.exceptions.HTTPError:
-            error_text = "Error occured when fetching further detail data"
-            logger.exception(error_text)
-            raise CantPullFromRcaApi(error_text)
 
-        data = response.json()
+        data = fetch_data(detail)
+        if not data:
+            return []
+
         if "social_image" in data and data["social_image"]:
             social_image = data["social_image"]["meta"]["detail_url"]
-            social_image = requests.get(url=social_image, timeout=5)
+            social_image = requests.get(url=social_image, timeout=10)
             social_image = social_image.json()
             if "url" in social_image["rca2019_feed_image"]:
                 social_image_url = social_image["rca2019_feed_image"]["url"]
@@ -77,7 +102,7 @@ def parse_items_to_list(data, type):
                 _item["image"] = social_image_url
                 _item["image_small"] = social_image_small_url
                 _item["image_alt"] = social_image["alt"]
-        date = False
+        date = None
         if type == "News":
             date = data["date"]
             _item["type"] = type
@@ -113,9 +138,12 @@ def parse_items_to_list(data, type):
 
 
 def pull_news_and_events(programme_type_slug=None):
-    # 'News' is actually a mixture of NewItem and RcaBlogPage models.
+    # 'News' is actually a mixture of NewsItem and RcaBlogPage models.
     # So pull 3 of both from the API and order them by the date field.
     # Then select how many we need depending on the events content.
+    NEWS_ITEMS = 3
+    # By default, work with 3 news items but if we pull events, get 2
+    # so we end up with 2 x News/Blog and 1 x Event.
 
     # First get the Events
     query = QueryDict(mutable=True)
@@ -134,25 +162,15 @@ def pull_news_and_events(programme_type_slug=None):
     query = query.urlencode()
     events_url = f"{settings.API_CONTENT_BASE_URL}/api/v2/pages/?{query}"
 
-    # By default, work with 3 news items but if we pull events, get 2
-    # so we end up with 2 x News/Blog and 1 x Event.
-    news_items_to_get = 3
-
     events_data = []
-    try:
-        response = requests.get(url=events_url, timeout=5)
-        response.raise_for_status()
-        logger.info("pulling Events from API")
-    except requests.exceptions.HTTPError:
-        error_text = "Error occured when fetching event data"
-        logger.exception(error_text)
-        raise CantPullFromRcaApi(error_text)
-    else:
-        data = response.json()
-
-        if data["meta"]["total_count"] > 0:
-            news_items_to_get = 2
-            events_data = parse_items_to_list(data, "Event")
+    fetched_event_data = fetch_data(events_url)
+    if (
+        fetched_event_data
+        and "total_count" in fetched_event_data["meta"]
+        and fetched_event_data["meta"]["total_count"] > 0
+    ):
+        NEWS_ITEMS = 2
+        events_data = parse_items_to_list(fetched_event_data, "Event")
 
     # News and Blogs
     # Pull 3 Blog items
@@ -171,17 +189,10 @@ def pull_news_and_events(programme_type_slug=None):
 
     query = query.urlencode()
     blog_url = f"{settings.API_CONTENT_BASE_URL}/api/v2/pages/?{query}"
-    try:
-        response = requests.get(url=blog_url, timeout=5)
-        response.raise_for_status()
-        logger.info("Pulling Blogs from API")
-    except requests.exceptions.HTTPError:
-        error_text = "Error occured when fetching Blog data"
-        logger.exception(error_text)
-        raise CantPullFromRcaApi(error_text)
-    else:
-        data = response.json()
-        blog_data = parse_items_to_list(data, "News")
+    fetched_blog_data = fetch_data(blog_url)
+    # Blog and News are both being used for News content, so they can
+    # both go to the parser as 'News'.
+    blog_data = parse_items_to_list(fetched_blog_data, "News")
 
     # Pull 3 News items
     query = QueryDict(mutable=True)
@@ -199,24 +210,15 @@ def pull_news_and_events(programme_type_slug=None):
     news_url = f"{settings.API_CONTENT_BASE_URL}/api/v2/pages/?{query}"
     news_data = []
 
-    try:
-        response = requests.get(url=news_url, timeout=5)
-        response.raise_for_status()
-        logger.info("Pulling News from API")
-    except requests.exceptions.HTTPError:
-        error_text = "Error occured when fetching News data"
-        logger.exception(error_text)
-        raise CantPullFromRcaApi(error_text)
-    else:
-        data = response.json()
-        news_data = parse_items_to_list(data, "News")
+    fetched_news_data = fetch_data(news_url)
+    news_data = parse_items_to_list(fetched_news_data, "News")
 
     news_and_blog_data = news_data + blog_data
     # Sort by the date
     news_and_blog_data.sort(key=lambda x: x["original_date"])
     news_and_blog_data.reverse()
     # Slice for how many items we want to get depending on the Events pulled.
-    news_and_blog_data = news_and_blog_data[:news_items_to_get]
+    news_and_blog_data = news_and_blog_data[:NEWS_ITEMS]
 
     return news_and_blog_data + events_data
 
@@ -236,24 +238,16 @@ def pull_alumni_stories(programme_type_slug=None):
             "show_on_homepage": "true",
         }
     )
-    alumni_stories_standrad_page_data = []
+    alumni_stories_standard_page_data = []
     if programme_type_slug:
         query.update({"rp": programme_type_slug})
     query = query.urlencode()
     url = f"{settings.API_CONTENT_BASE_URL}/api/v2/pages/?{query}"
-    try:
-        response = requests.get(url=url, timeout=5)
-        response.raise_for_status()
-        logger.info("pulling Alumni Stories from API")
-    except requests.exceptions.HTTPError:
-        error_text = "Error occured when fetching alumni stories data"
-        logger.exception(error_text)
-        raise CantPullFromRcaApi(error_text)
-    else:
-        data = response.json()
-        alumni_stories_standrad_page_data = parse_items_to_list(
-            data, "alumni_stories_standard_page"
-        )
+
+    fetched_alumni_stories_data = fetch_data(url)
+    alumni_stories_standard_page_data = parse_items_to_list(
+        fetched_alumni_stories_data, "alumni_stories_standard_page_data"
+    )
 
     # Pull 3 BlogPage items
     query = QueryDict(mutable=True)
@@ -270,21 +264,13 @@ def pull_alumni_stories(programme_type_slug=None):
         query.update({"rp": programme_type_slug})
     query = query.urlencode()
     url = f"{settings.API_CONTENT_BASE_URL}/api/v2/pages/?{query}"
-    try:
-        response = requests.get(url=url, timeout=5)
-        response.raise_for_status()
-        logger.info("pulling Alumni Stories from API")
-    except requests.exceptions.HTTPError:
-        error_text = "Error occured when fetching alumni stories data"
-        logger.exception(error_text)
-        raise CantPullFromRcaApi(error_text)
-    else:
-        data = response.json()
-        alumni_stories_blog_page_data = parse_items_to_list(
-            data, "alumni_stories_blog_page"
-        )
+
+    fetched_blog_data = fetch_data(url)
+    alumni_stories_blog_page_data = parse_items_to_list(
+        fetched_blog_data, "alumni_stories_blog_page"
+    )
 
     alumni_stories_data = (
-        alumni_stories_blog_page_data + alumni_stories_standrad_page_data
+        alumni_stories_blog_page_data + alumni_stories_standard_page_data
     )
     return alumni_stories_data

--- a/rca/project_styleguide/templates/patterns/pages/home/home_page.html
+++ b/rca/project_styleguide/templates/patterns/pages/home/home_page.html
@@ -87,18 +87,17 @@
                     </div>
 
 
-                    <div class="section__container">
+                    {% if news_and_events %}
+                        <div class="section__container">
+                            <header class="section__header grid">
+                                <h3 class="section__heading section__heading--primary heading heading--two">What&#39;s happening at the RCA</h3>
+                            </header>
+                                <div class="section__content grid">
+                                    {% include "patterns/organisms/news/news_api_content.html" with news=news_and_events %}
+                                </div>
+                        </div>
+                    {% endif %}
 
-                        <header class="section__header grid">
-                            <h3 class="section__heading section__heading--primary heading heading--two">What&#39;s happening at the RCA</h3>
-                        </header>
-                        {% if news_and_events %}
-                            <div class="section__content grid">
-                                {% include "patterns/organisms/news/news_api_content.html" with news=news_and_events %}
-                            </div>
-                        {% endif %}
-
-                    </div>
 
                 </section>
 

--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -702,5 +702,3 @@ API_CONTENT_CACHE_TIMEOUT = int(env.get("API_CONTENT_CACHE_TIMEOUT", 60 * 60 * 2
 # The API url to pull content from for the homepage, see rca.api_content.content
 API_CONTENT_BASE_URL = env.get("API_CONTENT_BASE_URL", "https://rca.ac.uk")
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 2000
-
-CACHE_CONTROL_STALE_IF_ERROR = env.get("CACHE_CONTROL_STALE_IF_ERROR", None)

--- a/rca/utils/cache.py
+++ b/rca/utils/cache.py
@@ -22,17 +22,11 @@ def get_default_cache_control_kwargs():
     stale_while_revalidate = getattr(
         settings, "CACHE_CONTROL_STALE_WHILE_REVALIDATE", None
     )
-    # Set stale-if-error so Cloudflare can serve stale cache if server errors are encountered.
-    # Note: this will be ignored if using Cloudflare's 'Always on-line' functionality.
-    stale_if_error = getattr(settings, "CACHE_CONTROL_STALE_IF_ERROR", None)
-
     cache_control_kwargs = {
         "s_maxage": s_maxage,
         "stale_while_revalidate": stale_while_revalidate,
-        "stale_if_error": stale_if_error,
         "public": True,
     }
-
     return {k: v for k, v in cache_control_kwargs.items() if v is not None}
 
 


### PR DESCRIPTION
If the verdant site we pull content from over the api is down, we should handle the timeout because heroku will crash at 30 seconds