### PR TITLE
Update revisions missing programme_type as it's causing viewing errors

### DIFF
--- a/rca/programmes/migrations/0051_update_revisions.py
+++ b/rca/programmes/migrations/0051_update_revisions.py
@@ -1,0 +1,25 @@
+import json
+
+from django.core.serializers.json import DjangoJSONEncoder
+from django.db import migrations
+
+from rca.programmes.models import ProgrammePage
+
+
+def update_revisions_with_current_programme_type(apps, schema_editor):
+    for page in ProgrammePage.objects.all():
+        programme_type = page.programme_type_id
+        for revision in page.revisions.all():
+            revision_data = json.loads(revision.content_json)
+            revision_data["programme_type"] = programme_type
+            revision.content_json = json.dumps(revision_data, cls=DjangoJSONEncoder)
+            revision.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("programmes", "0050_merge_20200206_1206"),
+    ]
+    operations = [
+        migrations.RunPython(update_revisions_with_current_programme_type),
+    ]

--- a/rca/programmes/migrations/0051_update_revisions.py
+++ b/rca/programmes/migrations/0051_update_revisions.py
@@ -3,10 +3,9 @@ import json
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import migrations
 
-from rca.programmes.models import ProgrammePage
-
 
 def update_revisions_with_current_programme_type(apps, schema_editor):
+    ProgrammePage = apps.get_model("programmes", "ProgrammePage")
     for page in ProgrammePage.objects.all():
         programme_type = page.programme_type_id
         for revision in page.revisions.all():

--- a/rca/programmes/migrations/0051_update_revisions.py
+++ b/rca/programmes/migrations/0051_update_revisions.py
@@ -17,9 +17,5 @@ def update_revisions_with_current_programme_type(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-    dependencies = [
-        ("programmes", "0050_merge_20200206_1206"),
-    ]
-    operations = [
-        migrations.RunPython(update_revisions_with_current_programme_type),
-    ]
+    dependencies = [("programmes", "0050_merge_20200206_1206")]
+    operations = [migrations.RunPython(update_revisions_with_current_programme_type)]


### PR DESCRIPTION
We made some changes to programme types a while back which saw us delete all the existing taxonomy items, this has caused errors when viewing page revisions with dangling taxonomy links. 
This PR has a migration to update all the page revisions to have programme_type values