### PR TITLE
Feature/316 short courses be

### DIFF
--- a/rca/project_styleguide/templates/patterns/pages/shortcourses/short_course.yaml
+++ b/rca/project_styleguide/templates/patterns/pages/shortcourses/short_course.yaml
@@ -31,7 +31,7 @@ context:
     introduction_image: True
     introduction: 'Understand the purpose of design thinking in promoting innovation and learn real-world applications and strategies for design thinking.'
     body: '<p>At the RCA, we teach design thinking, training designers who go on to lead global brands worldwide as creative directors and CEOs. In contrast to standard, linear approaches that build on tested models, design thinking is creatively structured, analytic and responsive. It draws in diverse disciplines and multiple areas of expertise and exploration, starting with the core premise that everything is a design problem.</p><p>Through the application of this informed analysis within business-driven, public-facing and community-centred contexts, design thinking can produce innovation, which in turn enables brands to remain competitive in changing markets.</p>'
-    location: 'Royal College of Art Kensington Gore'
+    location: '<a href="#">Royal College of Art Kensington Gore</a>'
     shortcourse_details_register_link: '#'
     about:
       - path:
@@ -97,9 +97,11 @@ context:
           author: 'Kevin Howbrook'
           link: 'http://www.torchbox.com'
           course: 'Design'
+    staff_title: Programme team
     staff_link: false
-    contact_image: true
-    relatedcontent: true
+    contact_image: True
+    contact_text: Get in touch if you’d like to find out more or have any questions about working with the RCA.
+    related_programmes: True
     show_register_link: True
   related_staff:
     - {
@@ -137,9 +139,12 @@ context:
     contact_title: Contact Us
     related_content_title: More opportunities to study at the RCA
   related_links:
-    - { text: 'Knowledge Exchange', href: '#' }
-    - { text: 'Custom Executive Education', href: '#' }
-    - { text: 'Innovation RCA', href: '#' }
+    - item:
+      value: { text: 'Knowledge Exchange', href: '#' }
+    - item:
+      value: { text: 'Custom Executive Education', href: '#' }
+    - item:
+      value: { text: 'Innovation RCA', href: '#' }
   booking_bar:
     message: 'Next course starts Thursday 19 March 2020'
     action: 'Book now for £900'


### PR DESCRIPTION
Depends on https://github.com/torchbox/rca-wagtail-2019/pull/335
So best to wait for that merge before reviewing this

Remaining Back End work for the short courses page
Ticket: https://projects.torchbox.com/projects/rca-website-rebuild/tickets/316

TODO 
- [x] Better organization of cms field in the admin UI
- [x] reset migrations
- [x] Fix tests
- [x] Fix related content images
- [x] Move accessPlanit info to it's own admin tab
- [x] Fix up related staff FE once template fixes are there