### PR TITLE
Update vagrant Postgres

### DIFF
--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -17,6 +17,7 @@ apt-get update -y
 service postgresql stop
 apt-get remove -y --purge postgresql-*
 apt-get install -y postgresql-11 postgresql-client-11 postgresql-contrib-11
+pg_ctlcluster 11 main start
 su - postgres -c "createuser -s vagrant"
 
 

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -16,8 +16,8 @@ apt-get update -y
 # Upgrade to postgres 11
 service postgresql stop
 apt-get remove -y --purge postgresql-*
-apt-get install -y postgresql-11 postgresql-client-11 postgresql-contrib-11
-pg_ctlcluster 11 main start
+apt-get install -y postgresql-12 postgresql-client-12 postgresql-contrib-12
+pg_ctlcluster 12 main start
 su - postgres -c "createuser -s vagrant"
 
 


### PR DESCRIPTION
While provisioning the vagrant vm I hit an error with Postgres not starting. This can be fixed by explicitly starting Postgres.
I've also updated Postgres to version 12 to avoid version mismatches.