### PR TITLE
Swap for ReadTimeout because it extends Timeout and is being caught b…

### DIFF
--- a/rca/api_content/content.py
+++ b/rca/api_content/content.py
@@ -5,7 +5,7 @@ import requests
 from bs4 import BeautifulSoup
 from django.conf import settings
 from django.http.request import QueryDict
-from requests.exceptions import ConnectionError, HTTPError, Timeout
+from requests.exceptions import ConnectionError, HTTPError, ReadTimeout
 
 """
 Static methods for adding content from the live RCA api
@@ -44,7 +44,7 @@ def fetch_data(url):
     try:
         response = requests.get(url, timeout=10)
         response.raise_for_status()
-    except Timeout:
+    except ReadTimeout:
         logger.exception(f"Timeout error occurred when fetching data from {url}")
         raise CantPullFromRcaApi(
             "Error occured when fetching further detail data from {url}"


### PR DESCRIPTION
…y sentry

see [sentry issue](https://sentry.io/organizations/torchbox/issues/1603072847/?project=1542908&query=is%3Aunresolved)

Previous task was to catch the Timeout's being thrown if the api request took too long (10 senconds). However sentry is catching [ReadTimeout](https://2.python-requests.org/en/v3.0.0/_modules/requests/exceptions/#ReadTimeout) (making the logs noisy)

