### PR TITLE
286 Add short courses to the programmes listing API and results views

### DIFF
--- a/rca/programmes/models.py
+++ b/rca/programmes/models.py
@@ -8,6 +8,7 @@ from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import models
 from django.utils.text import slugify
 from modelcluster.fields import ParentalKey
+from rest_framework.fields import CharField as CharFieldSerializer
 from wagtail.admin.edit_handlers import (
     FieldPanel,
     InlinePanel,
@@ -596,16 +597,21 @@ class ProgrammePage(BasePage):
         ),
     ]
     api_fields = [
-        APIField("degree_level", serializer=degree_level_serializer()),
+        # Fields for filtering and display, shared with shortcourses.ShortCoursePage.
         APIField("subjects"),
         APIField("programme_type"),
-        APIField("programme_description_subtitle"),
-        APIField("pathway_blocks"),
+        APIField("related_schools_and_research_pages"),
+        APIField(
+            "summary",
+            serializer=CharFieldSerializer(source="programme_description_subtitle"),
+        ),
         APIField(
             name="hero_image_square",
             serializer=ImageRenditionField("fill-580x580", source="hero_image"),
         ),
-        APIField("related_schools_and_research_pages"),
+        # Displayed fields, specific to programmes.
+        APIField("degree_level", serializer=degree_level_serializer()),
+        APIField("pathway_blocks"),
     ]
 
     def get_alumni_stories(self, programme_type_legacy_slug):

--- a/rca/shortcourses/models.py
+++ b/rca/shortcourses/models.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
+from rest_framework.fields import CharField as CharFieldSerializer
 from wagtail.admin.edit_handlers import (
     FieldPanel,
     InlinePanel,
@@ -251,10 +252,11 @@ class ShortCoursePage(BasePage):
     )
 
     api_fields = [
+        # Fields for filtering and display, shared with programmes.ProgrammePage.
         APIField("subjects"),
         APIField("programme_type"),
         APIField("related_schools_and_research_pages"),
-        APIField("introduction"),
+        APIField("summary", serializer=CharFieldSerializer(source="introduction")),
         APIField(
             name="hero_image_square",
             serializer=ImageRenditionField("fill-580x580", source="hero_image"),

--- a/rca/shortcourses/models.py
+++ b/rca/shortcourses/models.py
@@ -14,8 +14,10 @@ from wagtail.admin.edit_handlers import (
     StreamFieldPanel,
     TabbedInterface,
 )
+from wagtail.api import APIField
 from wagtail.core.fields import RichTextField, StreamField
 from wagtail.images import get_image_model_string
+from wagtail.images.api.fields import ImageRenditionField
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.snippets.edit_handlers import SnippetChooserPanel
 
@@ -247,6 +249,17 @@ class ShortCoursePage(BasePage):
             ObjectList(BasePage.settings_panels, heading="Settings"),
         ]
     )
+
+    api_fields = [
+        APIField("subjects"),
+        APIField("programme_type"),
+        APIField("related_schools_and_research_pages"),
+        APIField("introduction"),
+        APIField(
+            name="hero_image_square",
+            serializer=ImageRenditionField("fill-580x580", source="hero_image"),
+        ),
+    ]
 
     def get_access_planit_data(self):
         access_planit_course_data = AccessPlanitXML(

--- a/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesCategories/CategoriesPanels.js
@@ -6,7 +6,7 @@ import { programmeCategories } from '../../programmes.types';
 import CategoryItem from './CategoryItem';
 
 /**
- * Tabs for all categories programmes can be filtered by.
+ * Tabs for all categories pages can be filtered by.
  * All tabs are rendered to the DOM so screen readers’ ARIA markup
  * is correct.
  */

--- a/rca/static_src/javascript/programmes/components/ProgrammesExplorer.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesExplorer.js
@@ -10,8 +10,8 @@ import ProgrammesResults from './ProgrammesResults/ProgrammesResults';
 import ProgrammesCategories from './ProgrammesCategories/ProgrammesCategories';
 
 /**
- * Programmes listing, with a search form, filters, and a results view.
- * Programmes come from the Wagtail API (via Redux), UI state is synced in the URL.
+ * Programmes and short courses listing, with a search form, filters, and a results view.
+ * Pages come from the Wagtail API (via Redux), UI state is synced in the URL.
  */
 const ProgrammesExplorer = ({ searchLabel, categories }) => {
     const loc = useLocation();

--- a/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammeTeaser.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammeTeaser.js
@@ -6,8 +6,6 @@ import {
     programmePageShape,
 } from '../../programmes.types';
 
-const shortCourseLabel = 'Short course';
-
 /**
  * A programme or short course’s teaser info, to be displayed as part of search results.
  * "Degree level" and "Pathway blocks" are for programmes only. Other fields are shared.
@@ -15,6 +13,8 @@ const shortCourseLabel = 'Short course';
 const ProgrammeTeaser = ({ programme, onMouseOver, onFocus }) => {
     const { meta, title, summary, degree_level, pathway_blocks } = programme;
     const isShortCourse = meta.type === SHORT_COURSE_PAGE_TYPE;
+    // Short courses have no degree level. Display a distinguishing label instead.
+    const degreeLabel = isShortCourse ? 'Short course' : degree_level.title;
 
     return (
         <a
@@ -30,7 +30,7 @@ const ProgrammeTeaser = ({ programme, onMouseOver, onFocus }) => {
                     </span>
                 </h2>
                 <small className="programme-teaser__degree">
-                    {isShortCourse ? shortCourseLabel : degree_level.title}
+                    {degreeLabel}
                 </small>
             </div>
             <div className="programme-teaser__info">

--- a/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammeTeaser.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammeTeaser.js
@@ -1,21 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { programmePageShape } from '../../programmes.types';
+import {
+    SHORT_COURSE_PAGE_TYPE,
+    programmePageShape,
+} from '../../programmes.types';
+
+const shortCourseLabel = 'Short course';
 
 /**
- * A programme’s teaser info, to be displayed as part of search results.
+ * A programme or short course’s teaser info, to be displayed as part of search results.
+ * "Degree level" and "Pathway blocks" are for programmes only. Other fields are shared.
  */
 const ProgrammeTeaser = ({ programme, onMouseOver, onFocus }) => {
-    const {
-        meta,
-        title,
-        degree_level,
-        programme_description_subtitle,
-        pathway_blocks,
-        introduction,
-    } = programme;
-    const isShortCourse = meta.type === 'shortcourses.ShortCoursePage';
+    const { meta, title, summary, degree_level, pathway_blocks } = programme;
+    const isShortCourse = meta.type === SHORT_COURSE_PAGE_TYPE;
 
     return (
         <a
@@ -31,16 +30,14 @@ const ProgrammeTeaser = ({ programme, onMouseOver, onFocus }) => {
                     </span>
                 </h2>
                 <small className="programme-teaser__degree">
-                    {isShortCourse ? 'Short course' : degree_level.title}
+                    {isShortCourse ? shortCourseLabel : degree_level.title}
                 </small>
             </div>
             <div className="programme-teaser__info">
                 <p className="programme-teaser__description body body--one">
-                    {isShortCourse
-                        ? introduction
-                        : programme_description_subtitle}
+                    {summary}
                 </p>
-                {!isShortCourse && pathway_blocks.length > 0 ? (
+                {pathway_blocks && pathway_blocks.length > 0 ? (
                     <div>
                         <p className="programme-teaser__pathways-heading">
                             Pathways:

--- a/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammeTeaser.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammeTeaser.js
@@ -13,7 +13,9 @@ const ProgrammeTeaser = ({ programme, onMouseOver, onFocus }) => {
         degree_level,
         programme_description_subtitle,
         pathway_blocks,
+        introduction,
     } = programme;
+    const isShortCourse = meta.type === 'shortcourses.ShortCoursePage';
 
     return (
         <a
@@ -29,14 +31,16 @@ const ProgrammeTeaser = ({ programme, onMouseOver, onFocus }) => {
                     </span>
                 </h2>
                 <small className="programme-teaser__degree">
-                    {degree_level.title}
+                    {isShortCourse ? 'Short course' : degree_level.title}
                 </small>
             </div>
             <div className="programme-teaser__info">
                 <p className="programme-teaser__description body body--one">
-                    {programme_description_subtitle}
+                    {isShortCourse
+                        ? introduction
+                        : programme_description_subtitle}
                 </p>
-                {pathway_blocks.length > 0 ? (
+                {!isShortCourse && pathway_blocks.length > 0 ? (
                     <div>
                         <p className="programme-teaser__pathways-heading">
                             Pathways:

--- a/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammeTeaser.test.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammeTeaser.test.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ProgrammeTeaser from './ProgrammeTeaser';
+
+const getMock = (type = 'Page', overrides = {}, id = 4) => ({
+    id,
+    meta: {
+        type,
+        detail_url: 'http://localhost/api/v3/pages/63/',
+        html_url: 'http://localhost/study/courses/architecture-summer-school/',
+        slug: 'architecture-summer-school',
+        first_published_at: '2020-04-27T12:38:20.275294+01:00',
+    },
+    title: 'Title summer school',
+    summary: 'Summary intense and immersive',
+    hero_image_square: {
+        url: '/media/images/soa_summer_course_image.fill-580x580.jpg',
+        width: 580,
+        height: 580,
+    },
+    ...overrides,
+});
+
+const getMockShortCourse = getMock.bind(null, 'shortcourses.ShortCoursePage');
+const getMockProgramme = getMock.bind(null, 'programmes.ProgrammePage', {
+    degree_level: { id: 6, title: 'MA' },
+    pathway_blocks: [
+        {
+            id: '586e1b58-c8b3-4077-9577-02b727e12cbc',
+            type: 'accordion_block',
+            value: {
+                heading: 'Exhibition Design',
+                preview_text: 'Preview text',
+                body: '<p>Body text</p>',
+                link: { title: '', url: '' },
+            },
+        },
+    ],
+});
+
+describe('ProgrammeTeaser', () => {
+    it('renders short course page', () => {
+        expect(
+            shallow(
+                <ProgrammeTeaser
+                    programme={getMockShortCourse()}
+                    onMouseOver={() => {}}
+                    onFocus={() => {}}
+                />,
+            ).text(),
+        ).toMatchInlineSnapshot(
+            `"Title summer schoolShort courseSummary intense and immersive"`,
+        );
+    });
+
+    it('renders programme page', () => {
+        expect(
+            shallow(
+                <ProgrammeTeaser
+                    programme={getMockProgramme()}
+                    onMouseOver={() => {}}
+                    onFocus={() => {}}
+                />,
+            ).text(),
+        ).toMatchInlineSnapshot(
+            `"Title summer schoolMASummary intense and immersivePathways:Exhibition Design"`,
+        );
+    });
+
+    it('renders programme page without pathways', () => {
+        expect(
+            shallow(
+                <ProgrammeTeaser
+                    programme={{ ...getMockProgramme(), pathway_blocks: [] }}
+                    onMouseOver={() => {}}
+                    onFocus={() => {}}
+                />,
+            ).text(),
+        ).not.toContain('Pathways:');
+    });
+});

--- a/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammesResults.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammesResults.js
@@ -48,7 +48,7 @@ const getResultsStatus = (
 };
 
 /**
- * A list of programmes matching a search or filter.
+ * A list of pages matching a search or filter.
  * The list auto-magically appears when matches are found.
  */
 const ProgrammesResults = ({

--- a/rca/static_src/javascript/programmes/programmes.api.js
+++ b/rca/static_src/javascript/programmes/programmes.api.js
@@ -8,6 +8,10 @@ import {
 
 const WAGTAIL_API_ENDPOINT = '/api/v3/pages';
 
+/**
+ * The programmes API queries multiple page types, with different fields for each.
+ * This array also determines the order in which the instances are displayed.
+ */
 const listedPageTypes = [
     {
         type: PROGRAMME_PAGE_TYPE,
@@ -54,7 +58,7 @@ export const getWagtailAPIQueryString = ({
 let abortGetProgrammes = new AbortController();
 
 /**
- * Retrieve programmes based on:
+ * Retrieve programme and short course pages based on:
  * @param {string} query – a textual search query.
  * @param {object} filters – A key-val mapping of filters.
  * Or both!

--- a/rca/static_src/javascript/programmes/programmes.api.js
+++ b/rca/static_src/javascript/programmes/programmes.api.js
@@ -1,18 +1,28 @@
 import PropTypes from 'prop-types';
 
-import { programmePage } from './programmes.types';
-
-const PROGRAMME_TYPE = 'programmes.ProgrammePage';
-const SHORT_COURSE_TYPE = 'shortcourses.ShortCoursePage';
-const PROGRAMME_FIELDS = [
-    'degree_level',
-    'programme_description_subtitle',
-    'pathway_blocks',
-    'hero_image_square',
-];
-const SHORT_COURSE_FIELDS = ['introduction', 'hero_image_square'];
+import {
+    PROGRAMME_PAGE_TYPE,
+    SHORT_COURSE_PAGE_TYPE,
+    programmePage,
+} from './programmes.types';
 
 const WAGTAIL_API_ENDPOINT = '/api/v3/pages';
+
+const listedPageTypes = [
+    {
+        type: PROGRAMME_PAGE_TYPE,
+        fields: [
+            'summary',
+            'hero_image_square',
+            'degree_level',
+            'pathway_blocks',
+        ],
+    },
+    {
+        type: SHORT_COURSE_PAGE_TYPE,
+        fields: ['summary', 'hero_image_square'],
+    },
+];
 
 /**
  * Generates a Wagtail API query string based on the given attributes.
@@ -54,10 +64,7 @@ export const getProgrammes = ({ query, filters = {} }) => {
     abortGetProgrammes.abort();
     abortGetProgrammes = new AbortController();
 
-    const requests = [
-        { type: PROGRAMME_TYPE, fields: PROGRAMME_FIELDS },
-        { type: SHORT_COURSE_TYPE, fields: SHORT_COURSE_FIELDS },
-    ].map(({ type, fields }) => {
+    const requests = listedPageTypes.map(({ type, fields }) => {
         const queryString = getWagtailAPIQueryString({
             search: query,
             filters,

--- a/rca/static_src/javascript/programmes/programmes.slice.js
+++ b/rca/static_src/javascript/programmes/programmes.slice.js
@@ -42,7 +42,7 @@ const { reducer, actions } = createSlice({
 export const { clearResults } = actions;
 
 /**
- * Get the matching programmes from the search API.
+ * Get the matching programmes and short courses from the search API.
  * @param {string} searchQuery
  */
 export const searchProgrammes = (searchQuery, filters = {}) => {

--- a/rca/static_src/javascript/programmes/programmes.types.js
+++ b/rca/static_src/javascript/programmes/programmes.types.js
@@ -1,24 +1,35 @@
 import PropTypes from 'prop-types';
 
+export const PROGRAMME_PAGE_TYPE = 'programmes.ProgrammePage';
+export const SHORT_COURSE_PAGE_TYPE = 'shortcourses.ShortCoursePage';
+
 /**
- * A Programme page’s serialised attributes, coming from the Wagtail API.
- * Please make sure this stays up-to-date with APIField and serializers.
+ * A ProgrammePage or ShortCoursePage’s serialised attributes, coming from the Wagtail API.
+ * Please make sure this stays up-to-date with api_field definitions and serializers.
  */
 export const programmePage = {
     id: PropTypes.number.isRequired,
     meta: PropTypes.shape({
-        type: PropTypes.string.isRequired,
+        type: PropTypes.oneOf([PROGRAMME_PAGE_TYPE, SHORT_COURSE_PAGE_TYPE])
+            .isRequired,
         detail_url: PropTypes.string.isRequired,
         html_url: PropTypes.string.isRequired,
         slug: PropTypes.string.isRequired,
         first_published_at: PropTypes.string.isRequired,
     }).isRequired,
     title: PropTypes.string.isRequired,
+    summary: PropTypes.string.isRequired,
+    hero_image_square: PropTypes.shape({
+        url: PropTypes.string.isRequired,
+        width: PropTypes.number.isRequired,
+        height: PropTypes.number.isRequired,
+    }).isRequired,
+    // Defined for ProgrammePage, but not ShortCoursePage.
     degree_level: PropTypes.shape({
         id: PropTypes.number.isRequired,
         title: PropTypes.string.isRequired,
-    }).isRequired,
-    programme_description_subtitle: PropTypes.string.isRequired,
+    }),
+    // Defined for ProgrammePage, but not ShortCoursePage.
     pathway_blocks: PropTypes.arrayOf(
         PropTypes.shape({
             id: PropTypes.string.isRequired,
@@ -33,12 +44,7 @@ export const programmePage = {
                 }).isRequired,
             }).isRequired,
         }),
-    ).isRequired,
-    hero_image_square: PropTypes.shape({
-        url: PropTypes.string.isRequired,
-        width: PropTypes.number.isRequired,
-        height: PropTypes.number.isRequired,
-    }).isRequired,
+    ),
 };
 
 export const programmePageShape = PropTypes.shape(programmePage);


### PR DESCRIPTION
See [tickets/286](https://projects.torchbox.com/projects/rca-website-rebuild/tickets/286) for the initial brief and testing steps. This adds instances of `shortcourses.ShortCoursePage` to the programmes’ listing view, which was so far only displaying instances of `programmes.ProgrammePage`.

This is implemented by doing two separate API calls in parallel, to reduce customisations on the Wagtail API side, after discussion with Kevin and [on Slack](https://torchbox.slack.com/archives/C03R0FNK7/p1589289353027100).

---

I slightly refactored the API field definitions so it’s a bit clearer they are meant to match (not a dealbreaker if they stop matching in the future, as long as it’s intentional, but for now they’re meant to match). The API client makes the two queries in parallel, flattens the results as a single array (that determines the order of the two groups currently, see comment on the ticket).

On the display side, I had to make changes for the programme-only fields to be optional. Decided not to rename too many of the things named "Programme<thing>", but at least update the comments to make it clear there are two page types – and added tests for `ProgrammeTeaser` since it’s where being aware of the two types is the most important.

---

If I had more time I’d probably have a look at API error handling. I can see the error correctly propagates to Redux, but it looks like I had never added something to actually display it ("please refresh the page and try again"). I’ll add a ticket for that.