### PR TITLE
[456] Upgrade Wagtail to 2.9

### DIFF
--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -643,6 +643,9 @@ AUTH_USER_MODEL = "users.User"
 # This name is displayed in the Wagtail admin.
 WAGTAIL_SITE_NAME = "RCA Website"
 
+# Preserve Wagtail < 2.8 behaviour
+WAGTAILEMBEDS_RESPONSIVE_HTML = True
+
 
 # This is used by Wagtail's email notifications for constructing absolute
 # URLs. Please set to the domain that users will access the admin site.

--- a/rca/wagtailapi/api.py
+++ b/rca/wagtailapi/api.py
@@ -1,7 +1,7 @@
 from wagtail.api.v2 import router
 
-from rca.wagtailapi.endpoints import NavigationEndpoint, PagesAPIEndpoint
+from rca.wagtailapi.views import NavigationAPIViewSet, PagesAPIViewSet
 
 api_router = router.WagtailAPIRouter("wagtailapi")
-api_router.register_endpoint("pages", PagesAPIEndpoint)
-api_router.register_endpoint("navigation", NavigationEndpoint)
+api_router.register_endpoint("pages", PagesAPIViewSet)
+api_router.register_endpoint("navigation", NavigationAPIViewSet)

--- a/rca/wagtailapi/views.py
+++ b/rca/wagtailapi/views.py
@@ -1,9 +1,5 @@
 from wagtail.api.v2 import views
-from wagtail.api.v2.filters import (
-    FieldsFilter,
-    ChildOfFilter,
-    DescendantOfFilter,
-)
+from wagtail.api.v2.filters import ChildOfFilter, DescendantOfFilter, FieldsFilter
 from wagtail.api.v2.serializers import PageSerializer
 
 from rca.navigation.models import NavigationSettings

--- a/rca/wagtailapi/views.py
+++ b/rca/wagtailapi/views.py
@@ -1,8 +1,8 @@
-from wagtail.api.v2 import endpoints
+from wagtail.api.v2 import views
 from wagtail.api.v2.filters import (
     FieldsFilter,
-    RestrictedChildOfFilter,
-    RestrictedDescendantOfFilter,
+    ChildOfFilter,
+    DescendantOfFilter,
 )
 from wagtail.api.v2.serializers import PageSerializer
 
@@ -10,19 +10,19 @@ from rca.navigation.models import NavigationSettings
 from rca.wagtailapi import filters
 
 
-class PagesAPIEndpoint(endpoints.PagesAPIEndpoint):
+class PagesAPIViewSet(views.PagesAPIViewSet):
     base_serializer_class = PageSerializer
     filter_backends = [
         # NOTE that the following filters should be listed before the SearchFilter.
         filters.DegreeLevelFilter,
         FieldsFilter,
-        RestrictedChildOfFilter,
-        RestrictedDescendantOfFilter,
+        ChildOfFilter,
+        DescendantOfFilter,
         filters.RelatedSchoolsFilter,
         filters.SubjectsFilter,
         filters.SearchFilter,
     ]
 
 
-class NavigationEndpoint(endpoints.BaseAPIEndpoint):
+class NavigationAPIViewSet(views.BaseAPIViewSet):
     model = NavigationSettings

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==2.2.12
-wagtail==2.8.1
+wagtail==2.9
 psycopg2==2.7.7
 wagtail-django-recaptcha==1.0
 django-pattern-library==0.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==2.2.12
-wagtail==2.7.2
+wagtail==2.8.1
 psycopg2==2.7.7
 wagtail-django-recaptcha==1.0
 django-pattern-library==0.2.4


### PR DESCRIPTION
This should allow us to utlise the custom tag model functionality that was added in this version:
https://docs.wagtail.io/en/v2.9/reference/pages/model_recipes.html#custom-tag-models