### PR TITLE
Add option to force Redis to use TLS

### DIFF
--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -168,11 +168,13 @@ DATABASES = {
 
 # Do not use the same Redis instance for other things like Celery!
 if "REDIS_URL" in env:
+    REDIS_FORCE_TLS = env.get("REDIS_FORCE_TLS", "true").lower() == "true"
+    REDIS_URL = env["REDIS_URL"]
+    if REDIS_FORCE_TLS:
+        REDIS_URL = REDIS_URL.replace("redis://", "rediss://")
+
     CACHES = {
-        "default": {
-            "BACKEND": "django_redis.cache.RedisCache",
-            "LOCATION": env["REDIS_URL"],
-        }
+        "default": {"BACKEND": "django_redis.cache.RedisCache", "LOCATION": REDIS_URL}
     }
 else:
     CACHES = {


### PR DESCRIPTION
This adds the REDIS_FORCE_TLS option to support forcing Heroku to use Redis over TLS as discussed at https://projects.torchbox.com/projects/sysadmin/tickets/4477