### PR TITLE
Remove duplication in staff profile page title

### DIFF
--- a/rca/project_styleguide/templates/patterns/pages/staff/staff_detail.html
+++ b/rca/project_styleguide/templates/patterns/pages/staff/staff_detail.html
@@ -6,7 +6,7 @@
     app--staff-detail theme-light
 {% endblock %}
 
-{% block title_prefix %}
+{% block title %}
     {% if page.staff_title %}{{ page.staff_title }}{% endif %} {% if page.first_name %}{{ page.first_name }}{% endif %} {% if page.last_name %}{{ page.last_name }}{% endif %}
 {% endblock %}
 


### PR DESCRIPTION
For [ticket 1134](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/1134)

This was originally overriding the `title_prefix` block with the staff member's name, but the _base.html_ template was outputting the page's title in the `title` block. This led to double title output.