### PR TITLE
Add 'Start-up' subtitle to appropriate projects on landing & project picker pages

### DIFF
--- a/rca/landingpages/models.py
+++ b/rca/landingpages/models.py
@@ -13,6 +13,7 @@ from wagtail.core.fields import StreamField
 from wagtail.images import get_image_model_string
 from wagtail.images.edit_handlers import ImageChooserPanel
 
+from rca.projects.models import ProjectPage
 from rca.utils.blocks import (
     CallToActionBlock,
     RelatedPageListBlock,
@@ -347,6 +348,9 @@ class LandingPage(LegacyNewsAndEventsMixin, BasePage):
                     related_school = page.related_school_pages.first()
                     if related_school:
                         meta = related_school.page.title
+
+                if isinstance(page, ProjectPage) and page.is_startup_project:
+                    meta = "Start-up"
 
                 related_pages.append(
                     {

--- a/rca/project_styleguide/templates/patterns/molecules/card/card--project.html
+++ b/rca/project_styleguide/templates/patterns/molecules/card/card--project.html
@@ -10,7 +10,9 @@
         {% if item.link %}</a>{% endif %}
         <div class="card__content-container">
             <div class="card__content">
-                {% if item.school %}
+                {% if item.is_startup_project %}
+                    <div class="card__meta card__school">Start-up</div>
+                {% elif item.school %}
                     <div class="card__meta card__school">{{ item.school }}</div>
                 {% endif %}
                 <h3 class="card__heading">

--- a/rca/project_styleguide/templates/patterns/molecules/card/card--project.html
+++ b/rca/project_styleguide/templates/patterns/molecules/card/card--project.html
@@ -1,5 +1,5 @@
 {% load wagtailcore_tags wagtailimages_tags %}
-<div class="card card--project{% if not item.school %} card--notch-space{% endif %}{% if item.image %} card--image{% endif %}{% if modifier %} card--{{ modifier }}{% endif %}">
+<div class="card card--project{% if not item.is_startup_project and not item.school %} card--notch-space{% endif %}{% if item.image %} card--image{% endif %}{% if modifier %} card--{{ modifier }}{% endif %}">
     {% if item.image %}
         {% image item.image fill-80x58 as image_small %}
         {% image item.image fill-392x284 as image_large %}

--- a/rca/projects/models.py
+++ b/rca/projects/models.py
@@ -6,6 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import models
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from wagtail.admin.edit_handlers import (
@@ -415,6 +416,10 @@ class ProjectPage(BasePage):
         context["related_projects"] = self.get_related_projects()
 
         return context
+
+    @cached_property
+    def is_startup_project(self):
+        return len(self.research_types.filter(research_type__title="Start-up")) > 0
 
 
 class ProjectPickerPage(BasePage):


### PR DESCRIPTION
For [ticket 1106](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/1106)

Adds new property `is_startup_project` to _ProjectPage_, which can then be referenced by templates, context processors etc. to determine whether to output the _Start-up_ subtitle instead of the school.