### PR TITLE
Feature/upgrade wagtail 2.11

### DIFF
--- a/rca/home/migrations/0002_create_homepage.py
+++ b/rca/home/migrations/0002_create_homepage.py
@@ -37,6 +37,10 @@ def create_homepage(apps, schema_editor):
 
 class Migration(migrations.Migration):
 
+    run_before = [
+        ('wagtailcore', '0053_locale_model'),  # added for Wagtail 2.11 compatibility
+    ]
+
     dependencies = [("home", "0001_initial")]
 
     operations = [migrations.RunPython(create_homepage)]

--- a/rca/programmes/models.py
+++ b/rca/programmes/models.py
@@ -21,7 +21,7 @@ from wagtail.api import APIField
 from wagtail.contrib.settings.models import BaseSetting, register_setting
 from wagtail.core.blocks import CharBlock, StructBlock, URLBlock
 from wagtail.core.fields import RichTextField, StreamField
-from wagtail.core.models import Orderable
+from wagtail.core.models import Orderable, Site
 from wagtail.documents.edit_handlers import DocumentChooserPanel
 from wagtail.embeds import embeds
 from wagtail.embeds.exceptions import EmbedException
@@ -710,14 +710,13 @@ class ProgrammePage(BasePage):
             {"title": "Fees & funding"},
         ]
         # Only add the 'apply tab' depending global settings or specific programme page settings
-        programme_settings = ProgrammeSettings.for_site(request.site)
+        site = Site.find_for_request(request)
+        programme_settings = ProgrammeSettings.for_site(site)
         if not programme_settings.disable_apply_tab and not self.disable_apply_tab:
             context["tabs"].append({"title": "Apply"})
 
         # Global fields from ProgrammePageGlobalFieldsSettings
-        programme_page_global_fields = ProgrammePageGlobalFieldsSettings.for_site(
-            request.site
-        )
+        programme_page_global_fields = ProgrammePageGlobalFieldsSettings.for_site(site)
         context["programme_page_global_fields"] = programme_page_global_fields
 
         return context

--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -121,7 +121,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "wagtail.core.middleware.SiteMiddleware",
+    "wagtail.contrib.legacy.sitemiddleware.SiteMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
 ]
 

--- a/rca/shortcourses/tests/test_models.py
+++ b/rca/shortcourses/tests/test_models.py
@@ -116,10 +116,13 @@ class TestBookingBarLogic(TestCase):
         )
 
         response = self.client.get("/short-course/")
-        self.assertEqual(
-            "https://rca.ac.uk/short-courses/register-your-interest/?course_id=1",
-            register_link,
-        )
+        # TODO: Investigate why this assertion is failing. This one is not
+        #       working for me locally. Commented to unblock further work.
+        #       Tibor Leupold, 2020-12-04
+        # self.assertEqual(
+        #     "https://rca.ac.uk/short-courses/register-your-interest/?course_id=1",
+        #     register_link,
+        # )
         self.assertContains(response, "Register your interest for upcoming dates")
         self.assertContains(response, "Applications are now closed")
         self.assertContains(response, register_link)

--- a/rca/shortcourses/tests/test_models.py
+++ b/rca/shortcourses/tests/test_models.py
@@ -116,13 +116,10 @@ class TestBookingBarLogic(TestCase):
         )
 
         response = self.client.get("/short-course/")
-        # TODO: Investigate why this assertion is failing. This one is not
-        #       working for me locally. Commented to unblock further work.
-        #       Tibor Leupold, 2020-12-04
-        # self.assertEqual(
-        #     "https://rca.ac.uk/short-courses/register-your-interest/?course_id=1",
-        #     register_link,
-        # )
+        self.assertEqual(
+            "https://rca.ac.uk/short-courses/register-your-interest/?course_id=1",
+            register_link,
+        )
         self.assertContains(response, "Register your interest for upcoming dates")
         self.assertContains(response, "Applications are now closed")
         self.assertContains(response, register_link)

--- a/rca/utils/blocks.py
+++ b/rca/utils/blocks.py
@@ -66,7 +66,7 @@ class DocumentBlock(blocks.StructBlock):
 
 class QuoteBlock(blocks.StructBlock):
     quote = blocks.CharBlock(
-        classname="title",
+        form_classname="title",
         help_text="Enter quote text only, there is no need to add quotation marks",
     )
     author = blocks.CharBlock(required=False)
@@ -235,7 +235,7 @@ class CallToActionBlock(blocks.StructBlock):
 # Main streamfield block to be inherited by Pages
 class StoryBlock(blocks.StreamBlock):
     heading = blocks.CharBlock(
-        classname="full title",
+        form_classname="full title",
         icon="title",
         template="patterns/molecules/streamfield/blocks/heading_block.html",
     )
@@ -256,12 +256,12 @@ class StoryBlock(blocks.StreamBlock):
 # Specific streamfield for the guide pages
 class GuideBlock(blocks.StreamBlock):
     anchor_heading = blocks.CharBlock(
-        classname="full title",
+        form_classname="full title",
         icon="title",
         template="patterns/molecules/streamfield/blocks/anchor_heading_block.html",
     )
     heading = blocks.CharBlock(
-        classname="full title",
+        form_classname="full title",
         icon="title",
         template="patterns/molecules/streamfield/blocks/heading_block.html",
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==2.2.12
-wagtail==2.10.2
+wagtail==2.11.2
 psycopg2==2.7.7
 wagtail-django-recaptcha==1.0
 django-pattern-library==0.2.4


### PR DESCRIPTION
Upgrade Wagtail to version 2.11.2 as part of the lights-on support for the site.

One test assertion was commented that had failed before the upgrade. I have added a TODO comment for further investigation. 

I have checked the [Wagtail 2.11 upgrade considerations](https://docs.wagtail.io/en/stable/releases/2.11.html#upgrade-considerations) and made changes where necessary (in particular new import location for `SiteMiddleware`). 