### PR TITLE
Stop logging everything

### DIFF
--- a/rca/api_content/content.py
+++ b/rca/api_content/content.py
@@ -100,8 +100,11 @@ def parse_items_to_list(data, type):
 
         if "social_image" in data and data["social_image"]:
             social_image = data["social_image"]["meta"]["detail_url"]
-            social_image = requests.get(url=social_image, timeout=10)
-            social_image = social_image.json()
+            social_image = fetch_data(url=social_image)
+            try:
+                social_image = social_image.json()
+            except AttributeError:
+                continue
             if "url" in social_image["rca2019_feed_image"]:
                 social_image_url = social_image["rca2019_feed_image"]["url"]
                 social_image_small_url = social_image["rca2019_feed_image_small"]["url"]


### PR DESCRIPTION
Ticket [656](https://projects.torchbox.com/projects/rca-website-rebuild/tickets/656)

The get request for the social image should go through the custom `fetch` method since it passes through the catching pattern. At the moment it's not, which is resulting in [ReadTimeout](https://sentry.io/organizations/torchbox/issues/?environment=production&project=1542908&query=is%3Aunresolved&statsPeriod=24h) exceptions being raised.

This will mean `CantPullFromRcaApi` will be raised, ideally, I'd like to completely silence this logging with the `settings.API_FETCH_LOGGING` env var I set up (the legacy site isn't very responsive to the requests) but they are still occasionally being logged in sentry