### PR TITLE
Allow new school pages to be viewable by is_staff for publishing

### DIFF
--- a/rca/schools/models.py
+++ b/rca/schools/models.py
@@ -4,6 +4,8 @@ from collections import defaultdict
 from django.apps import apps
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.http import Http404
+from django.shortcuts import render
 from django.utils.translation import ugettext_lazy as _
 from modelcluster.fields import ParentalKey
 from wagtail.admin.edit_handlers import (
@@ -172,6 +174,13 @@ class StudentPageStudentStories(models.Model):
 
 
 class SchoolPage(ContactFieldsMixin, LegacyNewsAndEventsMixin, BasePage):
+    # Allow staff to see the new school pages for publishing, anyone else
+    # should receive a 404 and get redirected to the legacy site.
+    def serve(self, request):
+        if not request.user.is_staff:
+            raise Http404
+        return render(request, self.template, self.get_context(request))
+
     template = "patterns/pages/schools/schools.html"
     introduction = RichTextField(blank=False, features=["link"])
     introduction_image = models.ForeignKey(

--- a/rca/schools/models.py
+++ b/rca/schools/models.py
@@ -5,7 +5,6 @@ from django.apps import apps
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.http import Http404
-from django.shortcuts import render
 from django.utils.translation import ugettext_lazy as _
 from modelcluster.fields import ParentalKey
 from wagtail.admin.edit_handlers import (
@@ -179,7 +178,7 @@ class SchoolPage(ContactFieldsMixin, LegacyNewsAndEventsMixin, BasePage):
     def serve(self, request):
         if not request.user.is_staff:
             raise Http404
-        return render(request, self.template, self.get_context(request))
+        return super().serve(request)
 
     template = "patterns/pages/schools/schools.html"
     introduction = RichTextField(blank=False, features=["link"])


### PR DESCRIPTION
So publishing can begin once we deploy the work... and so that we can preview the new pages, this PR adds a 404 response set on the schools serve method depending on the user.

All is_staff users should be able to see the new schools pages for publishing purposes, but the public should receive a 404 and be rerouted to the old site accordingly until the pages are ready. Eventually, when ready,  we'll remove the custom serve method altogether.