### PR TITLE
1142 - If external link is legacy site, do not open in new tab

### DIFF
--- a/rca/utils/wagtail_hooks.py
+++ b/rca/utils/wagtail_hooks.py
@@ -19,6 +19,7 @@ from rca.events.models import (
 from rca.people.models import AreaOfExpertise, DegreeStatus, DegreeType, Directorate
 from rca.programmes.models import DegreeLevel, ProgrammeType, Subject
 from rca.utils.models import ResearchTheme, ResearchType, Sector
+from rca.utils.templatetags.util_tags import is_external
 
 
 class DegreeLevelModelAdmin(ModelAdmin):
@@ -144,7 +145,8 @@ class TargetBlankExternalLinkHandler(LinkHandler):
     @classmethod
     def expand_db_attributes(cls, attrs):
         href = attrs["href"]
-        return f'<a href="{escape(href)}" target="_blank">'
+        target = "target=\"_blank\"" if is_external(href) else ""
+        return f'<a href="{escape(href)}"{target}>'
 
 
 @hooks.register("register_rich_text_features")

--- a/rca/utils/wagtail_hooks.py
+++ b/rca/utils/wagtail_hooks.py
@@ -145,7 +145,7 @@ class TargetBlankExternalLinkHandler(LinkHandler):
     @classmethod
     def expand_db_attributes(cls, attrs):
         href = attrs["href"]
-        target = "target=\"_blank\"" if is_external(href) else ""
+        target = 'target="_blank"' if is_external(href) else ""
         return f'<a href="{escape(href)}"{target}>'
 
 


### PR DESCRIPTION
https://projects.torchbox.com/projects/rca-django-cms-project/tickets/1142

Uses the existing template code function to check if 'external' link provided in rich text content is actually an RCA (eg legacy site) url, and does not add target attribute if so.