### PR TITLE
Feature/596 listing title accessibility

### DIFF
--- a/rca/project_styleguide/templates/patterns/pages/project/project_listing.html
+++ b/rca/project_styleguide/templates/patterns/pages/project/project_listing.html
@@ -1,9 +1,22 @@
 {% extends "patterns/base_page.html" %}
-{% load wagtailcore_tags wagtailimages_tags wagtailsettings_tags static %}
+{% load wagtailcore_tags wagtailimages_tags wagtailsettings_tags static util_tags %}
 {% get_settings %}
 
 {% block body_class %}
     app--project-listing no-hero
+{% endblock %}
+
+{% block title %}
+    {% if page.seo_title %}
+        {{ page.seo_title }}
+    {% else %}
+        {{ page.title }}
+    {% endif %}
+    {% get_all_active_filters filters as active_filters %}
+    {% if active_filters %}
+        – {{ active_filters }}
+    {% endif %}
+    – Page {{ results.number }} of {{ results.paginator.num_pages }}
 {% endblock %}
 
 {% block content %}

--- a/rca/project_styleguide/templates/patterns/pages/staff/staff_index.html
+++ b/rca/project_styleguide/templates/patterns/pages/staff/staff_index.html
@@ -1,5 +1,5 @@
 {% extends "patterns/base_page.html" %}
-{% load wagtailcore_tags wagtailimages_tags wagtailsettings_tags static %}
+{% load wagtailcore_tags wagtailimages_tags wagtailsettings_tags static util_tags %}
 {% get_settings %}
 
 {% block body_class %}
@@ -13,18 +13,12 @@
         {{ page.title }}
     {% endif %}
     –
-    {% for item in filters.items %}
-        {% for option in item.options %}
-            {% if option.active %}{{ option.title }}{% if not forloop.last %},{% endif %}{% endif %}
-        {% endfor %}
-    {% endfor %}
+    {% get_all_active_filters filters %}
     – Page {{ results.number }} of {{ results.paginator.num_pages }}
 {% endblock %}
 
 {% block content %}
-
     <div class="page page--no-hero">
-
         {# Hero #}
         <header class="page__header bg bg--dark">
             <div class="title-area title-area--research-centre grid">

--- a/rca/project_styleguide/templates/patterns/pages/staff/staff_index.html
+++ b/rca/project_styleguide/templates/patterns/pages/staff/staff_index.html
@@ -15,7 +15,7 @@
     –
     {% for item in filters.items %}
         {% for option in item.options %}
-            {% if option.active %}{{ option.title }}{% endif %}
+            {% if option.active %}{{ option.title }}{% if not forloop.last %},{% endif %}{% endif %}
         {% endfor %}
     {% endfor %}
     – Page {{ results.number }} of {{ results.paginator.num_pages }}

--- a/rca/project_styleguide/templates/patterns/pages/staff/staff_index.html
+++ b/rca/project_styleguide/templates/patterns/pages/staff/staff_index.html
@@ -12,8 +12,10 @@
     {% else %}
         {{ page.title }}
     {% endif %}
-    –
-    {% get_all_active_filters filters %}
+    {% get_all_active_filters filters as active_filters %}
+    {% if active_filters %}
+        – {{ active_filters }}
+    {% endif %}
     – Page {{ results.number }} of {{ results.paginator.num_pages }}
 {% endblock %}
 

--- a/rca/project_styleguide/templates/patterns/pages/staff/staff_index.html
+++ b/rca/project_styleguide/templates/patterns/pages/staff/staff_index.html
@@ -6,6 +6,21 @@
     app--staff-listing no-hero
 {% endblock %}
 
+{% block title %}
+    {% if page.seo_title %}
+        {{ page.seo_title }}
+    {% else %}
+        {{ page.title }}
+    {% endif %}
+    –
+    {% for item in filters.items %}
+        {% for option in item.options %}
+            {% if option.active %}{{ option.title }}{% endif %}
+        {% endfor %}
+    {% endfor %}
+    – Page {{ results.number }} of {{ results.paginator.num_pages }}
+{% endblock %}
+
 {% block content %}
 
     <div class="page page--no-hero">

--- a/rca/utils/filter.py
+++ b/rca/utils/filter.py
@@ -72,6 +72,9 @@ class TabStyleFilter:
         # to match template usage
         return self.name
 
+    def get_active_filters(self):
+        return [option for option in self.options if option["active"]]
+
     def __iter__(self):
         for value, label in self.queryset.values_list(
             self.option_value_field, self.option_label_field

--- a/rca/utils/templatetags/util_tags.py
+++ b/rca/utils/templatetags/util_tags.py
@@ -216,3 +216,20 @@ def richtext_force_external_links(value):
             link["target"] = "_blank"
         html = str(soup)
     return render_to_string("wagtailcore/shared/richtext.html", {"html": html})
+
+
+@register.simple_tag()
+def get_all_active_filters(filters):
+    """Function to return all active items from filters.
+
+    Args:
+        filters (list): of TabStyleFilter objects.
+
+    Returns:
+        str: of all active items from all filters.
+    """
+    all_active_filters = []
+    for f in filters["items"]:
+        for item in f.get_active_filters():
+            all_active_filters.append(item["title"])
+    return ", ".join(all_active_filters)


### PR DESCRIPTION
BE wise this implements a new template tag that returns a string of all active filter items so they can be used in the template for page titles
![Screenshot from 2021-04-13 10-06-33](https://user-images.githubusercontent.com/2128707/114529882-53a48e80-9c42-11eb-914a-0a4f8eb4ec88.png)
