### PR TITLE
731 Add CustomEmbedFinder to fix title attribute

### DIFF
--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -650,6 +650,10 @@ WAGTAIL_SITE_NAME = "RCA Website"
 # Preserve Wagtail < 2.8 behaviour
 WAGTAILEMBEDS_RESPONSIVE_HTML = True
 
+WAGTAILEMBEDS_FINDERS = [
+    {"class": "rca.utils.embed_finders.CustomOEmbedFinder"},
+]
+
 
 # This is used by Wagtail's email notifications for constructing absolute
 # URLs. Please set to the domain that users will access the admin site.

--- a/rca/utils/embed_finders.py
+++ b/rca/utils/embed_finders.py
@@ -1,0 +1,23 @@
+from wagtail.embeds.finders.oembed import OEmbedFinder
+
+from bs4 import BeautifulSoup
+
+
+class CustomOEmbedFinder(OEmbedFinder):
+    """OEmbed finder to set video iframe titles."""
+
+    def find_embed(self, url, max_width=None):
+        embed = super().find_embed(url, max_width)
+        if embed["type"] == "video":
+            soup = BeautifulSoup(embed["html"], "html.parser")
+            iframe = soup.find("iframe")
+
+            # a11y: set iframe title
+            try:
+                iframe.attrs["title"] = embed["title"]
+            except KeyError:
+                pass
+
+            embed["html"] = str(soup)
+
+        return embed

--- a/rca/utils/embed_finders.py
+++ b/rca/utils/embed_finders.py
@@ -1,6 +1,5 @@
-from wagtail.embeds.finders.oembed import OEmbedFinder
-
 from bs4 import BeautifulSoup
+from wagtail.embeds.finders.oembed import OEmbedFinder
 
 
 class CustomOEmbedFinder(OEmbedFinder):

--- a/rca/utils/tests/test_embed_finders.py
+++ b/rca/utils/tests/test_embed_finders.py
@@ -1,8 +1,7 @@
 from unittest.mock import patch
 
-from django.test import TestCase
-
 from bs4 import BeautifulSoup
+from django.test import TestCase
 
 from rca.utils.embed_finders import CustomOEmbedFinder
 
@@ -57,6 +56,5 @@ class CustomOEmbedFinderTest(TestCase):
         finder = CustomOEmbedFinder()
         result = finder.find_embed("www.example.com")
         self.assertEqual(
-            result["html"],
-            '<iframe src="www.example.com"></iframe>',
+            result["html"], '<iframe src="www.example.com"></iframe>',
         )

--- a/rca/utils/tests/test_embed_finders.py
+++ b/rca/utils/tests/test_embed_finders.py
@@ -1,0 +1,62 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from bs4 import BeautifulSoup
+
+from rca.utils.embed_finders import CustomOEmbedFinder
+
+
+@patch("rca.utils.embed_finders.OEmbedFinder.find_embed")
+class CustomOEmbedFinderTest(TestCase):
+    def test_video_iframe_title_is_set(self, mock_find_embed):
+        mock_find_embed.return_value = {
+            "html": '<iframe src="www.example.com"></iframe>',
+            "type": "video",
+            "title": "Some video",
+        }
+
+        finder = CustomOEmbedFinder()
+        result = finder.find_embed("www.example.com")
+        soup = BeautifulSoup(result["html"], "html.parser")
+        self.assertEqual(soup.find("iframe").attrs.get("title"), "Some video")
+
+    def test_nonvideo_iframe_title_is_not_set(self, mock_find_embed):
+        mock_find_embed.return_value = {
+            "html": '<iframe src="www.example.com"></iframe>',
+            "type": "not a video",
+            "title": "Not a video",
+        }
+
+        finder = CustomOEmbedFinder()
+        result = finder.find_embed("www.example.com")
+        soup = BeautifulSoup(result["html"], "html.parser")
+        self.assertEqual(soup.find("iframe").attrs.get("title"), None)
+
+    def test_video_output_html(self, mock_find_embed):
+        mock_find_embed.return_value = {
+            "html": '<iframe src="www.example.com"></iframe>',
+            "type": "video",
+            "title": "Some video",
+        }
+
+        finder = CustomOEmbedFinder()
+        result = finder.find_embed("www.example.com")
+        self.assertEqual(
+            result["html"],
+            '<iframe src="www.example.com" title="Some video"></iframe>',
+        )
+
+    def test_nonvideo_output_html(self, mock_find_embed):
+        mock_find_embed.return_value = {
+            "html": '<iframe src="www.example.com"></iframe>',
+            "type": "not a video",
+            "title": "Something else",
+        }
+
+        finder = CustomOEmbedFinder()
+        result = finder.find_embed("www.example.com")
+        self.assertEqual(
+            result["html"],
+            '<iframe src="www.example.com"></iframe>',
+        )


### PR DESCRIPTION
Ticket: https://projects.torchbox.com/projects/rca-website-rebuild/tickets/731

The added tests for the fix passes fine although I haven't been able to manually test on my local build due to this error:
`django.db.utils.IntegrityError: null value in column "hash" of relation "wagtailembeds_embed" violates not-null constraint`
More info on that error here https://github.com/wagtail/wagtail/issues/6764. 
Not sure if that's a problem with data pulled from develop but feel like this should be tackled in a seperate ticket for time constraints.