### PR TITLE
Update Django to fix CVE-2021-32052 & CVE-2021-31542

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.1.7
+Django==3.1.10
 wagtail==2.12.3
 # Pin treebeard to <4.5, see: https://github.com/wagtail/wagtail/issues/6820
 django-treebeard<4.5


### PR DESCRIPTION
Fixes CVE-2021-32052 & CVE-2021-31542

https://docs.djangoproject.com/en/3.1/releases/3.1.10/
https://docs.djangoproject.com/en/3.1/releases/3.1.9/