### PR TITLE
[1193] Allow modal close button to remain visible by hiding header

### DIFF
--- a/rca/project_styleguide/templates/patterns/base.html
+++ b/rca/project_styleguide/templates/patterns/base.html
@@ -31,7 +31,7 @@
         {% include "patterns/atoms/sprites/sprites.html" %}
 
         {% wagtailuserbar %}
-        <header class="app__header">
+        <header class="app__header" data-header>
             {% include "patterns/atoms/grid-lines/grid-lines.html" %}
             {% block header %}{% endblock %}
         </header>

--- a/rca/static_src/javascript/components/video-modal.js
+++ b/rca/static_src/javascript/components/video-modal.js
@@ -11,8 +11,10 @@ class VideoModal {
         this.iframe = this.modal.querySelector('iframe');
         this.src = this.iframe.getAttribute('src');
         this.body = document.querySelector('body');
+        this.header = document.querySelector('[data-header]');
         this.noScrollClass = 'no-scroll';
         this.activeClass = 'is-open';
+        this.hiddenHeaderClass = 'app__header--hidden';
         this.storeIframeSrc();
     }
 
@@ -33,6 +35,9 @@ class VideoModal {
             // show the modal
             this.modalWindow.classList.add(this.activeClass);
 
+            // hide the header
+            this.header.classList.add(this.hiddenHeaderClass);
+
             // add the autoplay url to the iframe
             if (
                 this.iframe.getAttribute('src') !== this.modal.dataset.embedUrl
@@ -50,6 +55,9 @@ class VideoModal {
 
             // hide the modal
             this.modalWindow.classList.remove(this.activeClass);
+
+            // show the header
+            this.header.classList.remove(this.hiddenHeaderClass);
 
             // stop the embed playing
             this.iframe.setAttribute('src', '');

--- a/rca/static_src/sass/components/_app.scss
+++ b/rca/static_src/sass/components/_app.scss
@@ -30,6 +30,11 @@
             transform: translate3d(0, 0, 0);
             background-color: $color--black;
         }
+
+        // Hide via z-index (for modals)
+        &--hidden {
+            @include z-index(base);
+        }
     }
 
     &__navigation {


### PR DESCRIPTION
Ticket [1193](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/1193).
Currently deploying to [dev](https://rca-development.herokuapp.com/).

Toggles header (via z-index) when modals are open in order to make the close button visible. At present, the header obscures the close button (see prod).

![Kapture 2021-05-24 at 13 59 15](https://user-images.githubusercontent.com/2553896/119351412-56aa8a00-bc98-11eb-9d4e-43e948cde295.gif)