### PR TITLE
[1316] Remove pointer on active menu items

### DIFF
--- a/rca/static_src/sass/layout/_header.scss
+++ b/rca/static_src/sass/layout/_header.scss
@@ -113,6 +113,7 @@
 
         .menu-active & {
             opacity: 1;
+            cursor: initial;
         }
     }
 
@@ -132,6 +133,7 @@
 
         .search-active & {
             opacity: 1;
+            cursor: initial;
         }
     }
 


### PR DESCRIPTION
Ticket [1316](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/1216).
Currently deploying to [dev](https://rca-development.herokuapp.com/).

Removes `cursor: pointer` on menu/search buttons when they're already active.

![Kapture 2021-05-24 at 14 27 25](https://user-images.githubusercontent.com/2553896/119354805-662bd200-bc9c-11eb-96e7-02e570d0adb1.gif)
