### PR TITLE
Align first and second navigation lists correctly

### DIFF
--- a/rca/static_src/sass/components/_nav.scss
+++ b/rca/static_src/sass/components/_nav.scss
@@ -52,11 +52,11 @@
         }
 
         @include media-query(large) {
-            padding-top: ($gutter * 9.5);
+            padding-top: 182px;
             max-height: $sub-nav-height--large;
 
             .headroom--pinned.headroom--not-top & {
-                padding-top: ($gutter * 8);
+                padding-top: 157px;
             }
         }
 
@@ -174,7 +174,7 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        padding: $gutter 0;
+        padding: $gutter 5px $gutter 0;
         color: $color--white;
 
         span {


### PR DESCRIPTION
Ticket [1215](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/1215).
Currently deploying to [dev](https://rca-development.herokuapp.com/).

Fix horizontal alignment between the first and subsequent navigation lists. Agreed with nl to do away with using the `$gutter` variable here as it no longer serves its purpose.

Before:
<img width="637" alt="Screenshot 2021-05-24 at 16 28 29" src="https://user-images.githubusercontent.com/2553896/119370763-9039c000-bcad-11eb-96e2-5a4f765eb589.png">

After:
<img width="626" alt="Screenshot 2021-05-24 at 16 28 41" src="https://user-images.githubusercontent.com/2553896/119370776-93cd4700-bcad-11eb-963d-4bc59529aa83.png">


Prevent longer menu items from reaching grid line/edge of element (subtle one).

Before:
<img width="283" alt="Screenshot 2021-05-24 at 16 32 25" src="https://user-images.githubusercontent.com/2553896/119370830-a778ad80-bcad-11eb-90e8-60372646c656.png">

After:
<img width="293" alt="Screenshot 2021-05-24 at 16 29 37" src="https://user-images.githubusercontent.com/2553896/119370925-c5dea900-bcad-11eb-89b8-d63e1b19f7b7.png">

