### PR TITLE
[1204] add school to programme page

### DIFF
--- a/rca/programmes/models.py
+++ b/rca/programmes/models.py
@@ -630,6 +630,11 @@ class ProgrammePage(ContactFieldsMixin, BasePage):
             bits.append(str(self.degree_level))
         return " ".join(bits)
 
+    def get_school(self):
+        related = self.related_schools_and_research_pages.select_related("page").first()
+        if related:
+            return related.page
+
     def clean(self):
         super().clean()
         errors = defaultdict(list)
@@ -701,6 +706,9 @@ class ProgrammePage(ContactFieldsMixin, BasePage):
         # Global fields from ProgrammePageGlobalFieldsSettings
         programme_page_global_fields = ProgrammePageGlobalFieldsSettings.for_site(site)
         context["programme_page_global_fields"] = programme_page_global_fields
+
+        # School
+        context["programme_school"] = self.get_school()
 
         return context
 

--- a/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.html
+++ b/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.html
@@ -35,7 +35,7 @@
             </div>
         {% endif %}
     {% else %}
-        {% if page.programme_details_credits or page.programme_details_time or page.programme_details_duration %}
+        {% if page.programme_details_credits or page.programme_details_time or page.programme_details_duration or programme_school %}
             <div class="key-details__section key-details__section--details">
                 {% if programme_page_global_fields.key_details_programme_details_title %}
                     <h4 class="body body--two key-details__sub-heading">{{ programme_page_global_fields.key_details_programme_details_title }}</h4>
@@ -55,6 +55,11 @@
                     <li class="key-details__list-item">
                         {{ page.get_programme_details_duration_display }}
                     </li>
+                    {% endif %}
+                    {% if programme_school %}
+                       <li class="key-details__list-item">
+                            <a href="{% pageurl programme_school %}">{{ programme_school.title }}</a>
+                        </li>
                     {% endif %}
                 </ul>
             </div>

--- a/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.html
+++ b/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.html
@@ -35,7 +35,7 @@
             </div>
         {% endif %}
     {% else %}
-        {% if page.programme_details_credits or page.programme_details_time or page.programme_details_duration or programme_school %}
+        {% if page.programme_details_credits or page.programme_details_time or page.programme_details_duration %}
             <div class="key-details__section key-details__section--details">
                 {% if programme_page_global_fields.key_details_programme_details_title %}
                     <h4 class="body body--two key-details__sub-heading">{{ programme_page_global_fields.key_details_programme_details_title }}</h4>
@@ -56,11 +56,16 @@
                         {{ page.get_programme_details_duration_display }}
                     </li>
                     {% endif %}
-                    {% if programme_school %}
-                       <li class="key-details__list-item">
-                            <a href="{% pageurl programme_school %}">{{ programme_school.title }}</a>
-                        </li>
-                    {% endif %}
+                </ul>
+            </div>
+        {% endif %}
+        {% if programme_school %}
+            <div class="key-details__section key-details__section--school">
+                <h4 class="body body--two key-details__sub-heading">School or Centre</h4>
+                <ul class="key-details__list">
+                    <li class="key-details__list-item">
+                         <a href="{% pageurl programme_school %}" class="link link--tertiary">{{ programme_school.title }}</a>
+                    </li>
                 </ul>
             </div>
         {% endif %}

--- a/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.yaml
+++ b/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.yaml
@@ -29,3 +29,5 @@ context:
     key_details_book_or_view_all_open_days_link_title: Book or view all open days
     key_details_application_deadline_title: Application deadline
     key_details_career_opportunities_title: Career opportunities
+  programme_school:
+    title: School of Architecture


### PR DESCRIPTION
Implements: https://projects.torchbox.com/projects/rca-django-cms-project/tickets/1204

Adds the first item in the list of related schools and research centres to the programme page.

![Screenshot from 2021-05-25 10-43-04](https://user-images.githubusercontent.com/3485411/119485652-3ee20d00-bd4f-11eb-8753-f723c4d4295f.png)
