### PR TITLE
Feature/796 fe editorial detail middle

### DIFF
--- a/rca/project_styleguide/templates/patterns/_pattern_library_only/streamfield/editorial_streamfield.html
+++ b/rca/project_styleguide/templates/patterns/_pattern_library_only/streamfield/editorial_streamfield.html
@@ -1,0 +1,10 @@
+{% include "patterns/molecules/streamfield/blocks/richtext_block.html" %}
+{% include "patterns/molecules/streamfield/blocks/image_block.html" %}
+{% include "patterns/molecules/streamfield/blocks/richtext_block.html" %}
+{% include "patterns/molecules/streamfield/blocks/anchor_heading_block.html" with value="Article one" %}
+{% include "patterns/molecules/streamfield/blocks/richtext_block.html" %}
+{% include "patterns/molecules/streamfield/blocks/richtext_block.html" %}
+{% include "patterns/molecules/streamfield/blocks/anchor_heading_block.html" with value="Article two"  %}
+{% include "patterns/molecules/streamfield/blocks/richtext_block.html" %}
+{% include "patterns/molecules/streamfield/blocks/quote_block.html" %}
+{% include "patterns/molecules/streamfield/blocks/richtext_block.html" %}

--- a/rca/project_styleguide/templates/patterns/molecules/streamfield/blocks/image_block.yaml
+++ b/rca/project_styleguide/templates/patterns/molecules/streamfield/blocks/image_block.yaml
@@ -1,5 +1,5 @@
 tags:
   image:
-    value.image width-878:
+    value.image fill-880x660 as my_image:
       raw: |
-        <img src="//placekitten.com/878/498" width="878" height="498" alt="Some alt">
+        <img src="//placekitten.com/880/660" width="880" height="660" alt="Some alt">

--- a/rca/project_styleguide/templates/patterns/molecules/streamfield/stream_block.html
+++ b/rca/project_styleguide/templates/patterns/molecules/streamfield/stream_block.html
@@ -1,5 +1,5 @@
 {% load wagtailcore_tags %}
 
 {% for block in value %}
-    {% include_block block with guide_page=guide_page %}
+    {% include_block block %}
 {% endfor %}

--- a/rca/project_styleguide/templates/patterns/molecules/text-teaser/text-teaser.html
+++ b/rca/project_styleguide/templates/patterns/molecules/text-teaser/text-teaser.html
@@ -2,7 +2,7 @@
 <div class="text-teaser">
     <div class="text-teaser__container grid">
         {% if teaser.title %}
-            <h2 class="text-teaser__heading heading heading--two">{{ teaser.title }}</h2>
+            <h2 class="text-teaser__heading heading {% if heading_size == 'small' %}heading--three{% else %}heading--two{% endif %}">{{ teaser.title }}</h2>
         {% endif %}
         <div class="text-teaser__content">
             {% if teaser.description %}

--- a/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail--no-video.yaml
+++ b/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail--no-video.yaml
@@ -11,3 +11,5 @@ context:
         title: News
     introduction: 'The Royal College of Art USA Inc. (RCA USA) welcomes renowned Apple designer Peter Russell-Clarke as its incoming Chair and President.'
     introduction_image: false
+    body:
+      - dummy

--- a/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail.html
+++ b/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail.html
@@ -75,23 +75,33 @@
 
                 </div>
 
+                <div class="section__notch">
+                    <div class="section__notch-fill section__notch-fill--third-col"></div>
+                </div>
+
             </section>
 
         </header>
 
         <div class="page__content">
 
-            <div class="section">
+            <div class="section bg bg--light">
 
-                <div class="section__row section__row--first grid">
+                <div class="section__row section__row--first-small section__row--last grid">
                     {% if not page.introduction_image %}
                         <div class="layout__start-one layout__span-two layout__@large-span-one u-large-bp-only">
                             {% include "patterns/molecules/key-details/key-details--editorial.html" %}
                         </div>
                     {% endif %}
                     <div class="streamfield rich-text layout__start-one layout__span-two layout__@large-start-two layout__@large-span-three">
-                        {% include "patterns/molecules/streamfield/stream_block.html" with value=page.body %}
+                        {% for block in page.body %}
+                            {% include_block block %}
+                        {% endfor %}
                     </div>
+                </div>
+
+                <div class="section__notch">
+                    <div class="section__notch-fill section__notch-fill--second-col"></div>
                 </div>
 
             </div>

--- a/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail.html
+++ b/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail.html
@@ -100,6 +100,16 @@
                     </div>
                 </div>
 
+                <div class="section__row">
+                    {% if page.inline_cta %}
+                        <div class="section__row section__row--last">
+                            {% for block in page.inline_cta %}
+                                {% include "patterns/molecules/text-teaser/text-teaser.html" with teaser=block.value heading_size="small" %}
+                            {% endfor %}
+                        </div>
+                    {% endif %}
+                </div>
+
                 <div class="section__notch">
                     <div class="section__notch-fill section__notch-fill--second-col"></div>
                 </div>

--- a/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail.html
+++ b/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail.html
@@ -90,7 +90,7 @@
                         </div>
                     {% endif %}
                     <div class="streamfield rich-text layout__start-one layout__span-two layout__@large-start-two layout__@large-span-three">
-                        {% include "patterns/molecules/streamfield/stream_block.html" with value=page.body guide_page=True %}
+                        {% include "patterns/molecules/streamfield/stream_block.html" with value=page.body %}
                     </div>
                 </div>
 

--- a/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail.yaml
+++ b/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail.yaml
@@ -13,6 +13,7 @@ context:
     introduction_image: true
     video: 'https://www.youtube.com/watch?v=glIIF-kBXf0'
     video_caption: Watch the course introduction
+    body: dummy
 
 tags:
   image:

--- a/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail.yaml
+++ b/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail.yaml
@@ -13,9 +13,13 @@ context:
     introduction_image: true
     video: 'https://www.youtube.com/watch?v=glIIF-kBXf0'
     video_caption: Watch the course introduction
-    body: dummy
+    body:
+      - dummy
 
 tags:
+  include_block:
+    block:
+      template_name: 'patterns/_pattern_library_only/streamfield/editorial_streamfield.html'
   image:
     hero_image fill-320x285 as image_small:
       target_var: image_small

--- a/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail.yaml
+++ b/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail.yaml
@@ -15,6 +15,13 @@ context:
     video_caption: Watch the course introduction
     body:
       - dummy
+    inline_cta:
+      - block:
+        value:
+          title: Interested in design as a catalyst for change?
+          description: In addition to the research themes, the School of Architecture created the Laboratory for Design & Machine Learning to conduct research into new interdisciplinary forms of designing, evaluation, and policymaking.
+          action: MA Design Products
+          link: '#'
 
 tags:
   include_block:


### PR DESCRIPTION
Adding streamfield and the main content area to the new editorial detail page

**Ticket URL:**
https://projects.torchbox.com/projects/rca-website-rebuild/tickets/796

**Local URLs:**
http://localhost:3000/pattern-library/render-pattern/patterns/pages/editorial/editorial_detail--no-video.html
http://localhost:3000/pattern-library/render-pattern/patterns/pages/editorial/editorial_detail.html

**Dev URLs:**
http://lrca-development.herokuapp.com/pattern-library/render-pattern/patterns/pages/editorial/editorial_detail--no-video.html
http://lrca-development.herokuapp.com/pattern-library/render-pattern/patterns/pages/editorial/editorial_detail.html

**Screenshots**
![Screenshot 2021-06-30 at 10 29 58](https://user-images.githubusercontent.com/298766/123937624-428c3380-d98e-11eb-9720-8e9827b9c593.png)

![Screenshot 2021-06-30 at 10 29 51](https://user-images.githubusercontent.com/298766/123937629-44ee8d80-d98e-11eb-96a2-b923826038b6.png)
