### PR TITLE
Add groups to admin user listing

### DIFF
--- a/rca/people/models.py
+++ b/rca/people/models.py
@@ -890,7 +890,7 @@ class StudentPage(PerUserPageMixin, BasePage):
 
             # Check if a group configuration exsists already for this user.
             group = Group.objects.filter(
-                name=f"Student: {self.student_user_account.username}"
+                name=self.student_user_account.student_group_name
             )
             if group:
                 # If we find a group already, we don't need to create one.
@@ -899,7 +899,7 @@ class StudentPage(PerUserPageMixin, BasePage):
             # Create a specific group for this student so they have edit access to their page
             # and their image collection
             specific_student_group = Group.objects.create(
-                name=f"Student: {self.student_user_account.username}"
+                name=self.student_user_account.student_group_name
             )
 
             # Create new add GroupPagePermission

--- a/rca/users/models.py
+++ b/rca/users/models.py
@@ -1,9 +1,27 @@
 from django.contrib.auth.models import AbstractUser
+from django.utils.safestring import mark_safe
 
 
 class User(AbstractUser):
     def is_student(self):
         return self.groups.filter(name="Students").exists()
+
+    @property
+    def student_group_name(self):
+        """
+        The name of the single student group for this student
+        """
+        if self.is_student():
+            return f"Student: {self.username}"
+
+    def group_links(self):
+        groups = self.groups.all()
+        if self.is_student():
+            groups = self.groups.exclude(name=self.student_group_name)
+        return [
+            mark_safe(f'<a href="/admin/groups/{ g.pk }/users/">{ g.name }</a>')
+            for g in groups
+        ]
 
     class Meta:
         ordering = [

--- a/rca/users/templates/wagtailusers/users/list.html
+++ b/rca/users/templates/wagtailusers/users/list.html
@@ -1,0 +1,53 @@
+{% load i18n wagtailusers_tags wagtailadmin_tags %}
+<table class="listing">
+    <thead>
+        <tr>
+            <th class="name">
+                {% if ordering == "name" %}
+                    <a href="{% url 'wagtailusers_users:index' %}" class="icon icon-arrow-down-after teal">
+                        {% trans "Name" %}
+                    </a>
+                {% else %}
+                    <a href="{% url 'wagtailusers_users:index' %}?ordering=name" class="icon icon-arrow-down-after">
+                        {% trans "Name" %}
+                    </a>
+                {% endif %}
+            </th>
+            <th class="username">
+                {% if ordering == "username" %}
+                    <a href="{% url 'wagtailusers_users:index' %}" class="icon icon-arrow-down-after teal">
+                        {% trans "Username" %}
+                    </a>
+                {% else %}
+                    <a href="{% url 'wagtailusers_users:index' %}?ordering=username" class="icon icon-arrow-down-after">
+                        {% trans "Username" %}
+                    </a>
+                {% endif %}
+            </th>
+            <th class="level">{% trans "Admin" %}</th>
+            <th class="level">{% trans "Groups" %}</th>
+            <th class="status">{% trans "Status" %}</th>
+            <th class="last-login">{% trans "Last Login" %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for user in users %}
+            <tr>
+                <td class="title" valign="top">
+                    <div class="title-wrapper">
+                        <span class="avatar small"><img src="{% avatar_url user size=25 %}" alt="" /></span>
+                        <a href="{% url 'wagtailusers_users:edit' user.pk %}">{{ user|user_display_name }}</a>
+                    </div>
+                    <ul class="actions">
+                        {% user_listing_buttons user %}
+                    </ul>
+                </td>
+                <td class="username" valign="top">{{ user.get_username }}</td>
+                <td class="level" valign="top">{% if user.is_superuser %}{% trans "Yes" %}{% endif %}</td>
+                <td class="group" valign="top">{{user.group_links|join:", "}}</td>
+                <td class="status" valign="top"><div class="status-tag {% if user.is_active %}primary{% endif %}">{% if user.is_active %}{% trans "Active" %}{% else %}{% trans "Inactive" %}{% endif %}</div></td>
+                <td {% if user.last_login %} class="human-readable-date" title="{{ user.last_login|date:"d M Y H:i" }}"{% endif %}>{% if user.last_login %}{% blocktrans with time_period=user.last_login|timesince %}{{ time_period }} ago{% endblocktrans %}{% endif %}</td>
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>


### PR DESCRIPTION
https://projects.torchbox.com/projects/rca-django-cms-project/tickets/1208

This was a lot simpler than I thought it would be. Initially I overode the URLs and views for the user listing, and then found I was only changing anything in the listing template anyway. 

It is not particularly performant to query the groups per user but I couldn't work out an easy way to improve this.