### PR TITLE
WIP student profile preview link

### DIFF
--- a/rca/people/admin/page_import_forms.py
+++ b/rca/people/admin/page_import_forms.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.contrib import admin
 from django.contrib.admin.widgets import AutocompleteSelect
 from django.contrib.auth import get_user_model
 from import_export.forms import ConfirmImportForm, ImportForm

--- a/rca/people/views.py
+++ b/rca/people/views.py
@@ -1,0 +1,43 @@
+from datetime import timedelta
+
+from django.core import signing
+from django.core.signing import TimestampSigner
+from django.http import Http404
+from django.shortcuts import get_object_or_404
+from wagtail.core.models import PageRevision
+
+
+def student_profile_preview(request, id_signed_string):
+    revision_id = signing.loads(id_signed_string)
+
+    # Optionally limit the age of the preview ID signing
+    # Requires timestamp signing when the link is created
+    # signer = TimestampSigner()
+    # try:
+    #     revision_id = signer.unsign(id_signed_string, max_age=timedelta(days=7))
+    # except signing.SignatureExpired:
+    #     raise Http404
+
+    revision = get_object_or_404(PageRevision, id=revision_id)
+
+    return revision.as_page_object().make_preview_request(
+        original_request=request,
+        # extra_request_attrs={
+        #     "wagtailreview_mode": "view",
+        #     "wagtailreview_reviewer": reviewer,
+        # },
+    )
+
+
+# TODO: Add a preview link to a tab on the StudentPage edit page with help text
+# link_url = reverse("student_profile_preview", kwargs={id_signed_string=signed_revision_id})
+
+# To create signed_revision_id for link:
+# from django.core import signing
+# signing.dumps(p.get_latest_revision().id)
+
+# To create signed_revision_id for link (timed):
+# from django.core.signing import TimestampSigner
+# signer = TimestampSigner()
+# signer.sign(p.get_latest_revision().id)
+# '11413:1m1WZf:MkT7MX0a_1aDetTEEf3h4bsCENK1C_vmYfwzqZuvbYQ'

--- a/rca/urls.py
+++ b/rca/urls.py
@@ -11,6 +11,8 @@ from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.utils.urlpatterns import decorate_urlpatterns
 
 from rca.account_management.views import CustomLoginView
+from rca.people import urls as people_urls
+from rca.people.views import student_profile_preview
 from rca.utils.cache import get_default_cache_control_decorator
 from rca.wagtailapi.api import api_router
 
@@ -24,6 +26,11 @@ private_urlpatterns = [
     path("django-admin/", admin.site.urls),
     path("admin/", include(wagtailadmin_urls)),
     path("documents2/", include(wagtaildocs_urls)),
+    path(
+        "profile/preview/<str:id_signed_string>/",
+        student_profile_preview,
+        name="student_profile_preview",
+    ),
     # Don’t use generic cache control for API endpoints.
     path("api/v3/", api_router.urls),
 ]


### PR DESCRIPTION
https://projects.torchbox.com/projects/rca-django-cms-project/tickets/1201

Add a shareable preview link for student profiles. 

Simply a publicly accessible (but unguessable) URL that shows a preview of a specific StudentPage revision. Equally use a page ID rather than a revision ID and simply show the latest revision, depending on client input