### PR TITLE
Feature/801 fe editorial events landing page

### DIFF
--- a/rca/project_styleguide/templates/patterns/organisms/news/news_api_content.html
+++ b/rca/project_styleguide/templates/patterns/organisms/news/news_api_content.html
@@ -1,4 +1,4 @@
-<div class="news">
+<div class="news {% if modifier %}{{ modifier }}{% endif %}">
     {% for item in news %}
 
         {% if forloop.first %}
@@ -16,8 +16,8 @@
         {% endif %}
 
         {% if forloop.last and not forloop.first %}
-                <a class="news__view-all link link--primary link--link body body--two" href="/news-and-events/">
-                    <span class="link__label">See all news & events</span>
+                <a class="news__view-all link link--primary link--link body body--two" href="{{ news_view_all.link|default:'/news-and-events/' }}">
+                    <span class="link__label">{{ news_view_all.title|default:'See all news & events' }}</span>
                     <svg class="link__icon" width="12" height="8"><use xlink:href="#arrow"></use></svg>
                 </a>
             </div>

--- a/rca/project_styleguide/templates/patterns/pages/editorial_event_landing/editorial_event_landing.html
+++ b/rca/project_styleguide/templates/patterns/pages/editorial_event_landing/editorial_event_landing.html
@@ -10,16 +10,15 @@
 
     <div class="page page--no-hero">
 
-        <header class="page__header bg bg--dark">
-            <div class="title-area title-area--landing-page grid">
-                <div class="title-area__content">
-                    {% if page.title %}
-                        <h1 class="title-area__heading heading heading--display-two">{{ page.title }}</h1>
-                    {% endif %}
+        {% if page.title %}
+            <header class="page__header bg bg--dark">
+                <div class="title-area title-area--landing-page grid">
+                    <div class="title-area__content">
+                            <h1 class="title-area__heading heading heading--display-two">{{ page.title }}</h1>
+                    </div>
                 </div>
-            </div>
-
-        </header>
+            </header>
+        {% endif %}
 
         <div class="page__content">
 
@@ -27,7 +26,7 @@
 
             {# News #}
             <section class="section section--start bg bg--dark anchor-heading" id="news">
-                <div class="section__row section__row--last schools__about--news">
+                <div class="section__row section__row--last">
                     <div class="section__header grid">
                         <h2 class="section__heading section__heading--primary heading heading--two">News</h2>
                     </div>
@@ -39,7 +38,7 @@
 
             {# Events #}
             <section class="section section--start anchor-heading bg bg--dark" id="events">
-                <div class="section__row section__row--last schools__about--news">
+                <div class="section__row section__row--last">
                     <div class="section__header grid">
                         <h2 class="section__heading section__heading--primary heading heading--two">Events</h2>
                     </div>

--- a/rca/project_styleguide/templates/patterns/pages/editorial_event_landing/editorial_event_landing.html
+++ b/rca/project_styleguide/templates/patterns/pages/editorial_event_landing/editorial_event_landing.html
@@ -1,0 +1,132 @@
+{% extends "patterns/base_page.html" %}
+{% load wagtailcore_tags wagtailimages_tags wagtailsettings_tags static %}
+{% get_settings %}
+
+{% block body_class %}
+    app--editorial-event-landing
+{% endblock %}
+
+{% block content %}
+
+    <div class="page page--no-hero">
+
+        <header class="page__header bg bg--dark">
+            <div class="title-area title-area--landing-page grid">
+                <div class="title-area__content">
+                    {% if page.title %}
+                        <h1 class="title-area__heading heading heading--display-two">{{ page.title }}</h1>
+                    {% endif %}
+                </div>
+            </div>
+
+        </header>
+
+        <div class="page__content">
+
+            {% include "patterns/molecules/jump-nav/jump-nav.html" with modifier="bg bg--dark" sticky=True item=tabs %}
+
+            {# News #}
+            <section class="section section--start bg bg--dark anchor-heading" id="news">
+                <div class="section__row section__row--last schools__about--news">
+                    <div class="section__header grid">
+                        <h2 class="section__heading section__heading--primary heading heading--two">News</h2>
+                    </div>
+                    <div class="section__content grid">
+                        {% include "patterns/organisms/news/news_api_content.html" with news=page.news news_view_all=page.news_view_all modifier="news--single-feature" %}
+                    </div>
+                </div>
+            </section>
+
+            {# Events #}
+            <section class="section section--start anchor-heading bg bg--dark" id="events">
+                <div class="section__row section__row--last schools__about--news">
+                    <div class="section__header grid">
+                        <h2 class="section__heading section__heading--primary heading heading--two">Events</h2>
+                    </div>
+                    <div class="section__content grid">
+                        {% include "patterns/organisms/news/news_api_content.html" with news=page.events news_view_all=page.events_view_all modifier="news--single-feature" %}
+                    </div>
+                </div>
+            </section>
+
+            {# Stories #}
+            <section class=" section section--start bg bg--dark anchor-heading" id="stories">
+
+                <div class="section__row section__row--last-small">
+                    <div class="section__header section__header--bottom-space grid">
+                        <h2 class="section__heading section__heading--secondary section__heading--tight heading heading--two">Stories</h2>
+                        {% if page.stories_intro %}
+                            <div class="section__introduction layout__start-one layout__span-two layout__@large-start-four layout__@large-span-one">
+                                {{ page.stories_intro|richtext }}
+                            </div>
+                        {% endif %}
+                    </div>
+                    {% if page.stories %}
+                    <div class="section__content grid">
+                        {% include "patterns/organisms/carousel/carousel.html" with carousel=page.stories modifier='carousel carousel--no-margin' datatag='data-carousel' %}
+                    </div>
+                    {% endif %}
+                    {% if page.stories_link %}
+                    <div class="section__action grid">
+                        <a class="layout__@large-start-two link link--primary link--link body body--two" href="{{ page.stories_link }}">
+                            <span class="link__label">Browse all stories</span>
+                            <svg width="12" height="8" class="link__icon" aria-hidden="true"><use xlink:href="#arrow"></use></svg>
+                        </a>
+                    </div>
+                    {% endif %}
+                </div>
+            </section>
+
+
+            {# Talks #}
+            <section class="section section--start bg bg--dark anchor-heading" id="talks">
+
+                <div class="section__row section__row--last-small">
+                    <div class="section__header section__header--bottom-space grid">
+                        <h2 class="section__heading section__heading--secondary section__heading--tight heading heading--two">
+                            Talks
+                        </h2>
+                        {% if page.talks_intro %}
+                            <div class="section__introduction layout__start-one layout__span-two layout__@large-start-four layout__@large-span-one">
+                                {{ page.talks_intro }}
+                            </div>
+                        {% endif %}
+                    </div>
+                    <div class="section__content">
+
+                        {% if page.talks_image %}
+                            {% include "patterns/organisms/image-video-block/image-video-block.html" with modal=page.talks_video out_of_grid=False curriculum=False heading=False has_meta=False copy=False subheading=False image=page.talks_image caption=page.talks_cta video=page.talks_video modifier="small-bottom-margin image-video-block--no-padding" %}
+                        {% endif %}
+
+                        {% if page.talks_link %}
+                        <div class="section__action grid">
+                            <a class="layout__@large-start-four link link--primary link--link body body--two" href="{{ page.talks_link }}">
+                                <span class="link__label">Browse all Talks</span>
+                                <svg width="12" height="8" class="link__icon" aria-hidden="true"><use xlink:href="#arrow"></use></svg>
+                            </a>
+                        </div>
+                        {% endif %}
+                    </div>
+                </div>
+
+            </section>
+
+            {# CTA #}
+            <section class="section section--start section--end bg bg--dark anchor-heading" id="media-centre">
+                <div class="section__row section__row--last">
+                    {% include "patterns/molecules/text-teaser/text-teaser.html" with teaser=page.cta_block %}
+                </div>
+            </section>
+
+            {# Contact #}
+            <section class="section bg bg--dark">
+                <div class="contact-anchor anchor-heading" id="contact" ></div>
+                <div class="section__row section__row--first">
+                    {% include "patterns/organisms/contact/contact.html" with heading=page.contact_model_title text=page.contact_model_text image=page.contact_model_image %}
+                </div>
+            </section>
+
+        </div>
+
+    </div>
+{% endblock %}

--- a/rca/project_styleguide/templates/patterns/pages/editorial_event_landing/editorial_event_landing.html
+++ b/rca/project_styleguide/templates/patterns/pages/editorial_event_landing/editorial_event_landing.html
@@ -77,7 +77,6 @@
                 </div>
             </section>
 
-
             {# Talks #}
             <section class="section section--start bg bg--dark anchor-heading" id="talks">
 

--- a/rca/project_styleguide/templates/patterns/pages/editorial_event_landing/editorial_event_landing.yaml
+++ b/rca/project_styleguide/templates/patterns/pages/editorial_event_landing/editorial_event_landing.yaml
@@ -1,0 +1,108 @@
+context:
+  page:
+    title: News & Events
+    news:
+      - item:
+        type: 'News'
+        title: 'Designs for Real Life'
+        description: '6 July 2021'
+        link: '#'
+        image: //placekitten.com/526/402
+        person: false
+      - item:
+        type: 'Talk'
+        title: 'Redefining Boundaries: Architecture Work-in-progress 2019'
+        description: '23 July 2021'
+        link: '#'
+        image: false
+        person: false
+      - item:
+        type: 'News'
+        title: 'Show 2018: School of Architecture: Making Space for the Future'
+        description: '23 July 2021'
+        link: '#'
+        image: false
+        person: false
+      - item:
+        type: 'Story'
+        title: 'Show 2018: School of Architecture: Making Space for the Future'
+        description: '23 July 2021'
+        link: '#'
+        image: false
+        person: false
+    news_view_all:
+      title: View all news
+      link: '#'
+    events:
+      - item:
+        type: 'Exhibition'
+        title: 'Designs for Real Life'
+        description: '6 July — 4 August 2021, Somerset House'
+        link: '#'
+        image: //placekitten.com/526/402
+        person: false
+      - item:
+        type: 'Lecture'
+        title: 'Redefining Boundaries: Architecture Work-in-progress 2019'
+        description: '23 November 2021, Online'
+        link: '#'
+        image: false
+        person: false
+      - item:
+        type: 'Exhibition'
+        title: 'Show 2018: School of Architecture: Making Space for the Future'
+        description: '23 November 2021, Battersea'
+        link: '#'
+        image: false
+        person: false
+      - item:
+        type: 'Open day'
+        title: 'Show 2018: School of Architecture: Making Space for the Future'
+        description: '23 November 2021, Whitehall'
+        link: '#'
+        image: false
+        person: false
+    events_view_all:
+      title: View all events
+      link: '#'
+    stories_intro: Characterised by its roots in creative and innovative practice, by engagement with partners in business, industry, government and communities.
+    stories_link: '#'
+    stories:
+      - slide:
+        title: 'Lorem ipsum dolor sit'
+        description: 'How innovative and disruptive technologies can address the world’s most intractable challenges'
+        image: true
+        link: '#'
+      - slide:
+        title: 'Lorem ipsum dolor sit'
+        description: 'How innovative and disruptive technologies can address the world’s most intractable challenges'
+        image: true
+        link: '#'
+      - slide:
+        title: 'Lorem ipsum dolor sit'
+        description: 'How innovative and disruptive technologies can address the world’s most intractable challenges'
+        image: true
+        link: '#'
+    talks_intro: The RCA is famed for its ability to attract leading practitioners and academics from across the creative spectrum.
+    talks_link: '#'
+    talks_image: true
+    talks_video: 'https://www.youtube.com/watch?v=glIIF-kBXf0'
+    talks_cta: Watch the course introduction
+    contact: true
+    contact_image: true
+    cta_block:
+      title: Media Centre
+      description: The Press Office manages relations between the College and the media, acting as the first point of contact for media queries and issuing news releases and statements on behalf of the College.
+      action: Launch the Media Centre
+      link: '#'
+  tabs:
+    - tab:
+      title: News
+    - tab:
+      title: Events
+    - tab:
+      title: Stories
+    - tab:
+      title: Talks
+    - tab:
+      title: Media Centre

--- a/rca/static_src/sass/components/_card.scss
+++ b/rca/static_src/sass/components/_card.scss
@@ -462,8 +462,11 @@
         &:first-child {
             padding-top: $gutter;
 
-            @include media-query(large) {
+            @include media-query(medium) {
                 padding-top: 0;
+            }
+
+            @include media-query(large) {
                 padding-bottom: $gutter; // additional space for border
             }
         }
@@ -513,6 +516,18 @@
                     }
                 }
             }
+        }
+    }
+
+    .news--single-feature .news__sub-features & {
+        &:first-child {
+            @include media-query(large) {
+                padding-bottom: 0;
+            }
+        }
+
+        @include media-query(medium) {
+            grid-row: auto;
         }
     }
 

--- a/rca/static_src/sass/components/_news.scss
+++ b/rca/static_src/sass/components/_news.scss
@@ -56,8 +56,21 @@
                 &:first-child {
                     border-top: 1px solid $color--grid-line-light;
 
-                    @include media-query(large) {
+                    @include media-query(medium) {
                         border-top: 0;
+                    }
+
+                    @include media-query(large) {
+                        border-bottom: 1px solid $color--grid-line-light;
+                    }
+                }
+            }
+        }
+
+        &--single-feature {
+            .card {
+                &:nth-child(2) {
+                    @include media-query(large) {
                         border-bottom: 1px solid $color--grid-line-light;
                     }
                 }
@@ -71,8 +84,21 @@
                 &:first-child {
                     border-top: 1px solid $color--grid-line-dark;
 
-                    @include media-query(large) {
+                    @include media-query(medium) {
                         border-top: 0;
+                    }
+
+                    @include media-query(large) {
+                        border-bottom: 1px solid $color--grid-line-dark;
+                    }
+                }
+            }
+        }
+
+        &--single-feature {
+            .card {
+                &:nth-child(2) {
+                    @include media-query(large) {
                         border-bottom: 1px solid $color--grid-line-dark;
                     }
                 }


### PR DESCRIPTION
New editorial and events landing page, includes a small refactor to the news listing to allow for four items in each feed (previously limited to three items).

Ticket:
https://projects.torchbox.com/projects/rca-website-rebuild/tickets/801

Dev URL (currently syncing):
https://rca-development.herokuapp.com/pattern-library/render-pattern/patterns/pages/editorial_event_landing/editorial_event_landing.html

Screenshots:

![Screenshot 2021-07-16 at 11 11 26](https://user-images.githubusercontent.com/298766/125932241-56577102-1f4b-45e6-9505-17a3fbaf127b.png)

![Screenshot 2021-07-16 at 11 11 20](https://user-images.githubusercontent.com/298766/125932244-b9efd5ef-2786-4148-8fca-d0641fe5b2a3.png)

