### PR TITLE
Upgrade/wagtail 2.14

### DIFF
--- a/rca/account_management/apps.py
+++ b/rca/account_management/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class AccountManagementConfig(AppConfig):
-    name = "account_management"
+    name = "rca.account_management"

--- a/rca/account_management/tests/test_forms.py
+++ b/rca/account_management/tests/test_forms.py
@@ -1,11 +1,10 @@
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, Permission
 from django.test import TestCase
 from django.urls import reverse
 from wagtail.core.models import (
     Collection,
     GroupCollectionPermission,
     GroupPagePermission,
-    Permission,
 )
 from wagtail_factories import CollectionFactory
 

--- a/rca/people/models.py
+++ b/rca/people/models.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
 from django.conf import settings
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
@@ -28,7 +28,6 @@ from wagtail.core.models import (
     GroupPagePermission,
     Orderable,
     Page,
-    Permission,
 )
 from wagtail.images import get_image_model_string
 from wagtail.images.edit_handlers import ImageChooserPanel

--- a/rca/people/tests/test_models.py
+++ b/rca/people/tests/test_models.py
@@ -1,11 +1,10 @@
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, Permission
 from django.test import TestCase
 from django.urls import reverse
 from wagtail.core.models import (
     Collection,
     GroupCollectionPermission,
     GroupPagePermission,
-    Permission,
 )
 from wagtail.tests.utils import WagtailPageTests, WagtailTestUtils
 from wagtail.tests.utils.form_data import inline_formset, rich_text

--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -803,3 +803,5 @@ if "CORS_ALLOWED_ORIGINS" in env:
 
 CORS_ALLOWED_ORIGIN_REGEXES = r"^/api/.*$"
 CORS_ALLOW_METHODS = ["GET", "OPTIONS"]
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 Django==3.2.6
 wagtail==2.14
-# Pin treebeard to <4.5, see: https://github.com/wagtail/wagtail/issues/6820
-django-treebeard<4.5
 psycopg2==2.8.6
 wagtail-django-recaptcha==1.0
 django-pattern-library==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ psycopg2==2.8.6
 wagtail-django-recaptcha==1.0
 django-pattern-library==0.3.0
 django-birdbath==0.0.2
-django-countries==7.0
+django-countries==7.2.1
 # Pin cryptography, see: https://github.com/docker/compose/issues/8105#issuecomment-777098885
 cryptography==3.3.2
 mailchimp-marketing==3.0.29

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==3.2.6
-wagtail==2.14
+wagtail==2.14.1
 psycopg2==2.8.6
 wagtail-django-recaptcha==1.0
 django-pattern-library==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Django==3.1.10
-wagtail==2.13.3
+Django==3.2.6
+wagtail==2.14
 # Pin treebeard to <4.5, see: https://github.com/wagtail/wagtail/issues/6820
 django-treebeard<4.5
 psycopg2==2.8.6

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -62,9 +62,9 @@ apt-get update -y
 apt-get install -y unzip
 rm -rf /tmp/awscli-bundle || true
 rm -rf /tmp/awscli-bundle.zip || true
-curl -sSL "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bundle.zip"
-unzip -q /tmp/awscli-bundle.zip -d /tmp
-/tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip -d /tmp
+/tmp/aws/install -i /usr/local/aws -b /usr/local/bin/aws
 
 # Add a couple of aliases to manage.py into .bashrc
 cat << EOF >> /home/vagrant/.bashrc

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -62,9 +62,9 @@ apt-get update -y
 apt-get install -y unzip
 rm -rf /tmp/awscli-bundle || true
 rm -rf /tmp/awscli-bundle.zip || true
-curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-unzip awscliv2.zip -d /tmp
-/tmp/aws/install -i /usr/local/aws -b /usr/local/bin/aws
+curl -sSL "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bundle.zip"
+unzip -q /tmp/awscli-bundle.zip -d /tmp
+python3 /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
 
 # Add a couple of aliases to manage.py into .bashrc
 cat << EOF >> /home/vagrant/.bashrc


### PR DESCRIPTION
Upgrade Wagtail to 2.14

[#938](https://projects.torchbox.com/projects/rca-website-rebuild/tickets/938)

There are no changes required to the wagtail code from the [upgrade requirements](https://docs.wagtail.io/en/latest/releases/2.14.html#wagtail-2-14-release-notes)

### Some changes were needed to specific imports.

Importing Permission from wagtail.core.models no longer works, the models have been moved to a subfolder.

Import like this
`from django.contrib.auth.models import Group, Permission`
- rca/people/models.py
- rca/account_management/tests/test_forms.py
- rca/people/tests/test_models.py

`name = "rca.account_management"`
- in rca/account_management/apps.py

django-treebeard can be unpinned: https://github.com/wagtail/wagtail/issues/6820#issuecomment-789746668