### PR TITLE
Removing invalid meta tag

### DIFF
--- a/rca/project_styleguide/templates/patterns/base_page.html
+++ b/rca/project_styleguide/templates/patterns/base_page.html
@@ -3,7 +3,6 @@
 {% load static wagtailuserbar wagtailcore_tags wagtailimages_tags navigation_tags util_tags %}
 
 {% block meta_tags %}
-    <meta http-equiv="cache-control" content="stale-if-error=300" />
     {% if GOOGLE_TAG_MANAGER_ID %}
         {# To enable GTM code you need to specify GOOGLE_TAG_MANAGER_ID in Heroku settings #}
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
I'm not totally sure what this does, but having spoken in #tech it looks like this doesn't actually do anything, thought i'd double check with you though @kevinhowbrook . It ideally needs removing to ensure our pages are validating.