### PR TITLE
Removing aria and “read more” link option

### DIFF
--- a/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--dev-all-fields.html
+++ b/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--dev-all-fields.html
@@ -31,8 +31,8 @@
                             <h2 class="introduction__text section__heading heading heading--five">
                                 {{ page.introduction }}
                             </h2>
-                            {% if page.about_page %}
-                                <a href="{% pageurl page.about_page %}" class="introduction__link link link--tertiary link--link" {% if page.title %}aria-label="More about {{ page.title }}"{% endif %}>
+                            {% if page.about_page and page.about_page.title %}
+                                <a href="{% pageurl page.about_page %}" class="introduction__link link link--tertiary link--link">
                                     <span class="link__label">{{ page.about_page.title }}</span>
                                     <svg width="12" height="8" class="link__icon" aria-hidden="true"><use xlink:href="#arrow"></use></svg>
                                 </a>

--- a/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--enterprise.html
+++ b/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--enterprise.html
@@ -36,9 +36,9 @@
                             <h2 class="introduction__text section__heading heading heading--five">
                                 {{ page.introduction }}
                             </h2>
-                            {% if page.about_page %}
-                                <a href="{% pageurl page.about_page %}" class="introduction__link link link--tertiary link--link" {% if page.title %}aria-label="More about {{ page.title }}"{% endif %}>
-                                    <span class="link__label">{% firstof page.about_page.title 'Read more' %}</span>
+                            {% if page.about_page and page.about_page.title %}
+                                <a href="{% pageurl page.about_page %}" class="introduction__link link link--tertiary link--link">
+                                    <span class="link__label">{{ page.about_page.title }}</span>
                                     <svg width="12" height="8" class="link__icon" aria-hidden="true"><use xlink:href="#arrow"></use></svg>
                                 </a>
                             {% endif %}

--- a/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--generic.html
+++ b/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--generic.html
@@ -31,9 +31,9 @@
                             <h2 class="introduction__text section__heading heading heading--five">
                                 {{ page.introduction }}
                             </h2>
-                            {% if page.about_page %}
-                                <a href="{% pageurl page.about_page %}" class="introduction__link link link--tertiary link--link" {% if page.title %}aria-label="More about {{ page.title }}"{% endif %}>
-                                    <span class="link__label">{% firstof page.about_page.title 'Read more' %}</span>
+                            {% if page.about_page and page.about_page.title %}
+                                <a href="{% pageurl page.about_page %}" class="introduction__link link link--tertiary link--link">
+                                    <span class="link__label">{{ page.about_page.title }}</span>
                                     <svg width="12" height="8" class="link__icon" aria-hidden="true"><use xlink:href="#arrow"></use></svg>
                                 </a>
                             {% endif %}

--- a/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--innovation.html
+++ b/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--innovation.html
@@ -36,9 +36,9 @@
                             <h2 class="introduction__text section__heading heading heading--five">
                                 {{ page.introduction }}
                             </h2>
-                            {% if page.about_page %}
-                                <a href="{% pageurl page.about_page %}" class="introduction__link link link--tertiary link--link" {% if page.title %}aria-label="More about {{ page.title }}"{% endif %}>
-                                    <span class="link__label">{% firstof page.about_page.title 'Read more' %}</span>
+                            {% if page.about_page and page.about_page.title %}
+                                <a href="{% pageurl page.about_page %}" class="introduction__link link link--tertiary link--link">
+                                    <span class="link__label">{{ page.about_page.title }}</span>
                                     <svg width="12" height="8" class="link__icon" aria-hidden="true"><use xlink:href="#arrow"></use></svg>
                                 </a>
                             {% endif %}

--- a/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--innovation.yaml
+++ b/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--innovation.yaml
@@ -6,7 +6,8 @@ context:
         depth: 2
         title: Research
     introduction: 'InnovationRCA is the Royal College of Art’s centre for enterprise and entrepreneurship, helping students and graduates transform compelling ideas into successful businesses.'
-    about_page: 'Read more'
+    about_page:
+      title: 'Read more'
     feature_image: true
     feature_heading: Our Programmes
     feature_meta_heading: Join a thriving community of more than 250 MPhil and PhD students

--- a/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--research.html
+++ b/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--research.html
@@ -36,9 +36,9 @@
                             <h2 class="introduction__text section__heading heading heading--five">
                                 {{ page.introduction }}
                             </h2>
-                            {% if page.about_page %}
-                                <a href="{% pageurl page.about_page %}" class="introduction__link link link--tertiary link--link" {% if page.title %}aria-label="More about {{ page.title }}"{% endif %}>
-                                    <span class="link__label">{% firstof page.about_page.title 'Read more' %}</span>
+                            {% if page.about_page and page.about_page.title %}
+                                <a href="{% pageurl page.about_page %}" class="introduction__link link link--tertiary link--link">
+                                    <span class="link__label">{{ page.about_page.title }}</span>
                                     <svg width="12" height="8" class="link__icon" aria-hidden="true"><use xlink:href="#arrow"></use></svg>
                                 </a>
                             {% endif %}

--- a/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--research.yaml
+++ b/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--research.yaml
@@ -6,9 +6,8 @@ context:
         depth: 2
         title: Research
     introduction: 'The Royal College of Art excels in world-leading design and art research and creative innovation.'
-    about_page: Read more
-    introduction_link: '#'
-    introduction_link_text: 'Read more'
+    about_page:
+      title: Read more about research
     page_list_title: Research centres & schools
     related_research_centres_schools:
       - item:


### PR DESCRIPTION
Removing aria as it was causing AXE errors when the text was totally different to the editor's label. 

We originally did this as all links were "Read more", however, editors have now been educated to use more descriptive labelling, meaning the aria is no longer required.