### PR TITLE
Removing style on form when content is added - lack of contrast

### DIFF
--- a/rca/static_src/sass/components/_form-item.scss
+++ b/rca/static_src/sass/components/_form-item.scss
@@ -508,12 +508,6 @@
                     background-color: $color--form-input-focus-darkbg;
                 }
             }
-
-            &#{$root}--has-content {
-                label {
-                    color: $color--white-24;
-                }
-            }
         }
 
         #{$root}__instruction {


### PR DESCRIPTION
Removing the content added state of forms as it didn't meet WCAG 2.1 contrast requirements