### PR TITLE
Don't bother trying to make a link if there is no target

### DIFF
--- a/rca/navigation/templatetags/navigation_tags.py
+++ b/rca/navigation/templatetags/navigation_tags.py
@@ -1,7 +1,10 @@
+import logging
+
 from django import template
 
 from rca.navigation.templatetags import utils
 
+logger = logging.getLogger(__name__)
 register = template.Library()
 
 
@@ -46,6 +49,9 @@ def primarynav(context):
                 if tertiary_pages:
                     for i in tertiary_pages:
                         if not i["page"] and not i["url"]:
+                            logger.warning(
+                                "A page has been deleted that is still referenced in the navigation."
+                            )
                             continue
                         tertiary_url = (
                             i["page"].get_url(request) if i["page"] else i["url"]


### PR DESCRIPTION
If a page is deleted, and the navigation item is updated, there is
potential to throw NoneType errors