### PR TITLE
Adding orange focus state to global search

### DIFF
--- a/rca/static_src/sass/components/_search.scss
+++ b/rca/static_src/sass/components/_search.scss
@@ -17,11 +17,14 @@
         appearance: none;
         border-radius: 0;
         width: 100%;
-        border-bottom: 1px solid $color--white;
+        border-bottom: 1px inset $color--white;
         padding: ($gutter / 2) ($gutter * 1.5) ($gutter / 2) ($gutter / 2);
+        transition: border-width $transition-cubic,
+            border-color $transition-cubic;
 
         &:focus {
             outline: 0;
+            border-bottom: 4px inset $color--tertiary;
         }
     }
 


### PR DESCRIPTION
Updating global search focus state

Ticket:
projects.torchbox.com/projects/rca-website-rebuild/tickets/1000

Staging:
rca-development.herokuapp.com/

<details>
<summary>Screenshots + </summary>
![Screenshot 2021-10-27 at 17 58 29](https://user-images.githubusercontent.com/298766/139112331-444e8ecc-56f9-462e-807d-652dfe7a36f2.png)
![Screenshot 2021-10-27 at 17 58 13](https://user-images.githubusercontent.com/298766/139112333-8453a080-502b-49e4-accf-079e2d0f69f2.png)
</details>