### PR TITLE
Feature/992 api tests

### DIFF
--- a/rca/editorial/factories.py
+++ b/rca/editorial/factories.py
@@ -1,7 +1,7 @@
 import factory
 import wagtail_factories
 
-from .models import EditorialPage, EditorialType
+from .models import Author, EditorialPage, EditorialType
 
 
 class EditorialTypeFactory(factory.django.DjangoModelFactory):
@@ -18,3 +18,10 @@ class EditorialPageFactory(wagtail_factories.PageFactory):
     title = factory.Faker("text", max_nb_chars=25)
     published_at = factory.Faker("date")
     introduction = factory.Faker("text", max_nb_chars=150)
+
+
+class AuthorFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Author
+
+    name = factory.Faker("text", max_nb_chars=25)

--- a/rca/editorial/models.py
+++ b/rca/editorial/models.py
@@ -272,7 +272,6 @@ class EditorialPage(ContactFieldsMixin, BasePage):
     api_fields = BasePage.api_fields + [
         APIField("hero_image"),
         APIField("introduction"),
-        APIField("hero_image"),
         APIField("video"),
         APIField("video_caption"),
         APIField("introduction_image"),

--- a/rca/editorial/tests/test_api.py
+++ b/rca/editorial/tests/test_api.py
@@ -1,33 +1,8 @@
-from django.test import TestCase
 from wagtail.tests.utils import WagtailPageTests
 
+from rca.editorial.factories import EditorialPageFactory, EditorialTypeFactory
+from rca.editorial.models import EditorialPageTypePlacement, EditorialType
 from rca.home.models import HomePage
-from rca.standardpages.models import IndexPage, InformationPage
-
-from .factories import EditorialPageFactory, EditorialTypeFactory
-from .models import (
-    EditorialListingPage,
-    EditorialPage,
-    EditorialPageTypePlacement,
-    EditorialType,
-)
-
-
-class TestEditorialFactories(TestCase):
-    def test_factories(self):
-        EditorialPageFactory()
-        # Test with type
-        type = EditorialTypeFactory()
-        EditorialPageFactory(editorial_types=[EditorialPageTypePlacement(type=type)])
-
-
-class EditorialListingPageTests(WagtailPageTests):
-    def test_can_add_only_editorial_child_pages(self):
-        self.assertCanNotCreateAt(EditorialListingPage, InformationPage)
-        self.assertCanNotCreateAt(EditorialListingPage, IndexPage)
-
-    def test_can_add_editorial_child_page(self):
-        self.assertCanCreateAt(EditorialListingPage, EditorialPage)
 
 
 class EditorialSerializerTests(WagtailPageTests):

--- a/rca/editorial/tests/test_api.py
+++ b/rca/editorial/tests/test_api.py
@@ -1,8 +1,173 @@
+import json
+
+import wagtail_factories
 from wagtail.tests.utils import WagtailPageTests
 
-from rca.editorial.factories import EditorialPageFactory, EditorialTypeFactory
-from rca.editorial.models import EditorialPageTypePlacement, EditorialType
+from rca.editorial.factories import (
+    AuthorFactory,
+    EditorialPageFactory,
+    EditorialTypeFactory,
+)
+from rca.editorial.models import (
+    EditorialPageDirectorate,
+    EditorialPageRelatedProgramme,
+    EditorialPageTypePlacement,
+    EditorialType,
+)
 from rca.home.models import HomePage
+from rca.people.factories import DirectorateFactory
+from rca.programmes.factories import ProgrammePageFactory
+from rca.schools.factories import SchoolPageFactory
+from rca.schools.models import RelatedSchoolPage
+
+
+class EditorialPageAPIResponseTest(WagtailPageTests):
+    """The RCA intranet import tool relies on the structure
+    of this API response, so it's covered with a test to ensure
+    that should the structure change, we are alerted about it as
+    it will break the importer on the intranet"""
+
+    def setUp(self):
+        # Created models for FK relationships
+        self.directorate = DirectorateFactory(title="ufos", intranet_slug="u-f-o-s")
+        self.programme_one = ProgrammePageFactory(
+            title="How to draw Aliens", intranet_slug="htd-aliens"
+        )
+        self.programme_two = ProgrammePageFactory(
+            title="How to erase Aliens", intranet_slug="hte-aliens"
+        )
+        self.school_one = SchoolPageFactory(
+            title="School one",
+            intranet_slug="school-one",
+            introduction_image=wagtail_factories.ImageFactory(),
+        )
+        self.school_two = SchoolPageFactory(
+            title="School two",
+            intranet_slug="school-two",
+            introduction_image=wagtail_factories.ImageFactory(),
+        )
+        editorial_type = EditorialTypeFactory(title="Alien news")
+
+        self.home_page = HomePage.objects.first()
+        self.editorial_page = EditorialPageFactory(
+            parent=self.home_page,
+            introduction="An introduction for the editorial page",
+            hero_image=wagtail_factories.ImageFactory(),
+            listing_image=wagtail_factories.ImageFactory(title="The listing image"),
+            contact_email="fox.mulder@fbi.com",
+            listing_title="The listing title",
+            listing_summary="A summary for listing",
+            body=json.dumps(
+                [
+                    {"type": "heading", "value": "the heading"},
+                    {"type": "image", "value": wagtail_factories.ImageFactory().pk},
+                    {"type": "paragraph", "value": "<p>A paragraph</p>"},
+                    {"type": "embed", "value": "https://rca.ac.uk"},
+                    {
+                        "type": "quote",
+                        "value": {
+                            "quote": "the quote",
+                            "author": "the author",
+                            "job_title": "publsiher",
+                        },
+                    },
+                ]
+            ),
+            cta_block=json.dumps(
+                [
+                    {
+                        "type": "call_to_action",
+                        "value": {
+                            "title": "The CTA title",
+                            "description": "A CTA description",
+                            "link": {
+                                "title": "A link",
+                                "url": "https//rca.ac.uk/ctalink",
+                            },
+                            "page": None,
+                        },
+                    }
+                ],
+            ),
+            author=AuthorFactory(name="Dana Scully"),
+        )
+        self.editorial_page.editorial_types = [
+            EditorialPageTypePlacement(page=self.editorial_page, type=editorial_type)
+        ]
+        self.editorial_page.related_schools = [
+            RelatedSchoolPage(source_page=self.editorial_page, page=self.school_one),
+            RelatedSchoolPage(source_page=self.editorial_page, page=self.school_two),
+        ]
+        self.editorial_page.related_directorates = [
+            EditorialPageDirectorate(
+                page=self.editorial_page, directorate=self.directorate
+            )
+        ]
+        self.editorial_page.related_programmes = [
+            EditorialPageRelatedProgramme(
+                source_page=self.editorial_page, page=self.programme_one
+            ),
+            EditorialPageRelatedProgramme(
+                source_page=self.editorial_page, page=self.programme_two
+            ),
+        ]
+        self.editorial_page.save()
+
+    def test_editorial_response(self):
+        response = self.client.get(f"/api/v3/pages/{self.editorial_page.id}/")
+        self.assertEqual(
+            response.data["listing_title"], "The listing title",
+        )
+        self.assertEqual(response.data["listing_summary"], "A summary for listing")
+        self.assertEqual(response.data["listing_image"]["title"], "The listing image")
+        self.assertEqual(
+            response.data["introduction"], "An introduction for the editorial page"
+        )
+        self.assertEqual(len(self.editorial_page.body), 5)
+        self.assertEqual(
+            response.data["published_at"],
+            self.editorial_page.published_at.strftime("%Y-%m-%d"),
+        )
+        self.assertEqual(response.data["contact_email"], "fox.mulder@fbi.com")
+        self.assertEqual(
+            response.data["related_directorates"],
+            [{"title": "ufos", "id": self.directorate.id, "intranet_slug": "u-f-o-s"}],
+        )
+        self.assertEqual(
+            response.data["related_programmes_api"],
+            [
+                {
+                    "page": {
+                        "title": "How to draw Aliens",
+                        "id": self.programme_one.id,
+                        "slug": "how-to-draw-aliens",
+                        "intranet_slug": "htd-aliens",
+                    }
+                },
+                {
+                    "page": {
+                        "title": "How to erase Aliens",
+                        "id": self.programme_two.id,
+                        "slug": "how-to-erase-aliens",
+                        "intranet_slug": "hte-aliens",
+                    }
+                },
+            ],
+        )
+        self.assertEqual(
+            response.data["related_schools"][0]["page"]["title"], "School one"
+        )
+        self.assertEqual(
+            response.data["related_schools"][0]["page"]["intranet_slug"], "school-one"
+        )
+        self.assertEqual(
+            response.data["related_schools"][1]["page"]["title"], "School two"
+        )
+        self.assertEqual(
+            response.data["related_schools"][1]["page"]["intranet_slug"], "school-two"
+        )
+        self.assertEqual(response.data["author_as_string"], "Dana Scully")
+        self.assertEqual(response.data["editorial_types"][0]["title"], "Alien news")
 
 
 class EditorialSerializerTests(WagtailPageTests):

--- a/rca/editorial/tests/test_models.py
+++ b/rca/editorial/tests/test_models.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+from wagtail.tests.utils import WagtailPageTests
+
+from rca.editorial.factories import EditorialPageFactory, EditorialTypeFactory
+from rca.editorial.models import (
+    EditorialListingPage,
+    EditorialPage,
+    EditorialPageTypePlacement,
+)
+from rca.standardpages.models import IndexPage, InformationPage
+
+
+class TestEditorialFactories(TestCase):
+    def test_factories(self):
+        EditorialPageFactory()
+        # Test with type
+        type = EditorialTypeFactory()
+        EditorialPageFactory(editorial_types=[EditorialPageTypePlacement(type=type)])
+
+
+class EditorialListingPageTests(WagtailPageTests):
+    def test_can_add_only_editorial_child_pages(self):
+        self.assertCanNotCreateAt(EditorialListingPage, InformationPage)
+        self.assertCanNotCreateAt(EditorialListingPage, IndexPage)
+
+    def test_can_add_editorial_child_page(self):
+        self.assertCanCreateAt(EditorialListingPage, EditorialPage)

--- a/rca/editorial/tests/test_models.py
+++ b/rca/editorial/tests/test_models.py
@@ -1,7 +1,11 @@
 from django.test import TestCase
 from wagtail.tests.utils import WagtailPageTests
 
-from rca.editorial.factories import EditorialPageFactory, EditorialTypeFactory
+from rca.editorial.factories import (
+    AuthorFactory,
+    EditorialPageFactory,
+    EditorialTypeFactory,
+)
 from rca.editorial.models import (
     EditorialListingPage,
     EditorialPage,
@@ -13,6 +17,7 @@ from rca.standardpages.models import IndexPage, InformationPage
 class TestEditorialFactories(TestCase):
     def test_factories(self):
         EditorialPageFactory()
+        AuthorFactory()
         # Test with type
         type = EditorialTypeFactory()
         EditorialPageFactory(editorial_types=[EditorialPageTypePlacement(type=type)])

--- a/rca/events/factories.py
+++ b/rca/events/factories.py
@@ -1,7 +1,14 @@
 import factory
 import wagtail_factories
 
-from .models import EventDetailPage, EventSeries, EventType
+from .models import (
+    EventAvailability,
+    EventDetailPage,
+    EventEligibility,
+    EventLocation,
+    EventSeries,
+    EventType,
+)
 
 
 class EventSeriesFactory(factory.django.DjangoModelFactory):
@@ -28,3 +35,22 @@ class EventDetailPageFactory(wagtail_factories.PageFactory):
     start_date = factory.Faker("date")
     end_date = factory.Faker("date")
     event_type = factory.SubFactory(EventTypeFactory)
+
+
+class EventAvailabilityFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = EventAvailability
+
+    title = factory.Faker("text", max_nb_chars=25)
+
+
+class EventLocationFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = EventLocation
+
+    title = factory.Faker("text", max_nb_chars=25)
+
+
+class EventEligibilityFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = EventEligibility

--- a/rca/events/tests/test_api.py
+++ b/rca/events/tests/test_api.py
@@ -1,0 +1,270 @@
+import json
+from datetime import date
+
+import wagtail_factories
+from wagtail.tests.utils import WagtailPageTests
+
+from rca.events.factories import (
+    EventAvailabilityFactory,
+    EventDetailPageFactory,
+    EventEligibilityFactory,
+    EventLocationFactory,
+    EventTypeFactory,
+)
+from rca.events.models import (
+    EventDetailPageRelatedDirectorate,
+    EventDetailPageRelatedPages,
+    EventDetailPageSpeaker,
+    EventType,
+)
+from rca.home.models import HomePage
+from rca.people.factories import DirectorateFactory, StaffPageFactory
+from rca.people.models import Directorate
+from rca.programmes.factories import ProgrammePageFactory
+from rca.schools.factories import SchoolPageFactory
+from rca.schools.models import RelatedSchoolPage
+
+
+class EventAPIResponseTest(WagtailPageTests):
+    """The RCA intranet import tool relies on the structure
+    of this API response, so it's covered with a test to ensure
+    that should the structure change, we are alerted about it as
+    it will break the importer on the intranet"""
+
+    def setUp(self):
+        # Created models for FK relationships
+        self.directorate = DirectorateFactory(title="ufos", intranet_slug="u-f-o-s")
+        self.programme_one = ProgrammePageFactory(
+            title="How to draw Aliens", intranet_slug="htd-aliens"
+        )
+        self.programme_two = ProgrammePageFactory(
+            title="How to erase Aliens", intranet_slug="hte-aliens"
+        )
+        self.related_event = EventDetailPageFactory(title="Alien xmas")
+        self.staff_one = StaffPageFactory()
+        self.staff_two = StaffPageFactory()
+        self.school_one = SchoolPageFactory(
+            title="School one",
+            intranet_slug="school-one",
+            introduction_image=wagtail_factories.ImageFactory(),
+        )
+        self.school_two = SchoolPageFactory(
+            title="School two",
+            intranet_slug="school-two",
+            introduction_image=wagtail_factories.ImageFactory(),
+        )
+
+        self.home_page = HomePage.objects.first()
+        self.event_page = EventDetailPageFactory(
+            parent=self.home_page,
+            event_type=EventTypeFactory(title="party"),
+            introduction="Welcome, to the introduction",
+            start_date=date(2021, 1, 6),
+            end_date=date(2021, 1, 6),
+            location=EventLocationFactory(title="Roswell"),
+            availability=EventAvailabilityFactory(title="Tickets still available"),
+            eligibility=EventEligibilityFactory(title="Aliens only"),
+            contact_model_email="fox.mulder@fbi.com",
+            hero_image=wagtail_factories.ImageFactory(),
+            listing_image=wagtail_factories.ImageFactory(title="The listing image"),
+            listing_title="The listing title",
+            listing_summary="A summary for listing",
+            manual_registration_url_link_text="Register now",
+            manual_registration_url="https://rca.ac.uk/register",
+            event_cost="$100",
+            body=json.dumps(
+                [
+                    {"type": "heading", "value": "the heading"},
+                    {"type": "image", "value": wagtail_factories.ImageFactory().pk},
+                    {"type": "paragraph", "value": "<p>A paragraph</p>"},
+                    {"type": "embed", "value": "https://rca.ac.uk"},
+                    {
+                        "type": "quote",
+                        "value": {
+                            "quote": "the quote",
+                            "author": "the author",
+                            "job_title": "publsiher",
+                        },
+                    },
+                ]
+            ),
+        )
+
+        self.event_page.related_directorates = [
+            EventDetailPageRelatedDirectorate(
+                source_page=self.event_page, directorate=self.directorate
+            )
+        ]
+        self.event_page.related_pages = [
+            EventDetailPageRelatedPages(
+                source_page=self.event_page, page=self.programme_one
+            ),
+            EventDetailPageRelatedPages(
+                source_page=self.event_page, page=self.programme_two
+            ),
+            EventDetailPageRelatedPages(
+                source_page=self.event_page, page=self.related_event
+            ),
+        ]
+        self.event_page.speakers = [
+            EventDetailPageSpeaker(source_page=self.event_page, page=self.staff_one),
+            EventDetailPageSpeaker(source_page=self.event_page, page=self.staff_two),
+            EventDetailPageSpeaker(
+                source_page=self.event_page,
+                first_name="Lister",
+                surname="Red",
+                link="https://rca.ac.uk/lister",
+            ),
+        ]
+        self.event_page.related_schools = [
+            RelatedSchoolPage(source_page=self.event_page, page=self.school_one),
+            RelatedSchoolPage(source_page=self.event_page, page=self.school_two),
+        ]
+        self.event_page.save()
+
+    def test_event_response(self):
+        response = self.client.get(f"/api/v3/pages/{self.event_page.id}/")
+
+        self.assertEqual(response.data["introduction"], "Welcome, to the introduction")
+        self.assertEqual(response.data["location"]["title"], "Roswell")
+        self.assertEqual(
+            response.data["availability"]["title"], "Tickets still available"
+        )
+        self.assertEqual(response.data["eligibility"]["title"], "Aliens only")
+        self.assertEqual(
+            response.data["contact_email"], [{"email_address": "fox.mulder@fbi.com"}]
+        )
+        self.assertEqual(
+            response.data["dates_times"],
+            [
+                {
+                    "date_from": "2021-01-06",
+                    "date_to": "2021-01-06",
+                    "time_from": "00:00:00",
+                    "time_to": "00:00:00",
+                }
+            ],
+        )
+        self.assertEqual(
+            response.data["related_directorates"],
+            [{"title": "ufos", "id": self.directorate.id, "intranet_slug": "u-f-o-s"}],
+        )
+        self.assertEqual(response.data["event_type"]["title"], "party")
+        self.assertEqual(
+            response.data["related_programmes"],
+            [
+                {
+                    "page": {
+                        "title": "How to draw Aliens",
+                        "id": self.programme_one.id,
+                        "slug": "how-to-draw-aliens",
+                        "intranet_slug": "htd-aliens",
+                    }
+                },
+                {
+                    "page": {
+                        "title": "How to erase Aliens",
+                        "id": self.programme_two.id,
+                        "slug": "how-to-erase-aliens",
+                        "intranet_slug": "hte-aliens",
+                    }
+                },
+            ],
+        )
+        self.assertEqual(
+            response.data["speakers"][0]["first_name_api"], self.staff_one.first_name
+        )
+        self.assertEqual(
+            response.data["speakers"][0]["surname_api"], self.staff_one.last_name
+        )
+        self.assertEqual(response.data["speakers"][0]["link_or_page"], None)
+        self.assertEqual(
+            response.data["speakers"][1]["first_name_api"], self.staff_two.first_name
+        )
+        self.assertEqual(
+            response.data["speakers"][1]["surname_api"], self.staff_two.last_name
+        )
+        self.assertEqual(response.data["speakers"][1]["link_or_page"], None)
+        self.assertEqual(response.data["speakers"][2]["first_name_api"], "Lister")
+        self.assertEqual(response.data["speakers"][2]["surname_api"], "Red")
+        self.assertEqual(
+            response.data["speakers"][2]["link_or_page"], "https://rca.ac.uk/lister"
+        )
+        self.assertEqual(
+            response.data["related_schools"][0]["page"]["title"], "School one"
+        )
+        self.assertEqual(
+            response.data["related_schools"][0]["page"]["intranet_slug"], "school-one"
+        )
+        self.assertEqual(
+            response.data["related_schools"][1]["page"]["title"], "School two"
+        )
+        self.assertEqual(
+            response.data["related_schools"][1]["page"]["intranet_slug"], "school-two"
+        )
+        self.assertEqual(
+            response.data["listing_title"], "The listing title",
+        )
+        self.assertEqual(response.data["listing_summary"], "A summary for listing")
+        self.assertEqual(response.data["listing_image"]["title"], "The listing image")
+        self.assertEqual(len(self.event_page.body), 5)
+        self.assertEqual(
+            response.data["manual_registration_url_link_text"], "Register now"
+        )
+        self.assertEqual(
+            response.data["manual_registration_url"], "https://rca.ac.uk/register"
+        )
+        self.assertEqual(response.data["event_cost"], "$100")
+
+
+class EventSerializerTests(WagtailPageTests):
+    def setUp(self):
+        self.home_page = HomePage.objects.first()
+        self.event_page = EventDetailPageFactory(
+            parent=self.home_page, event_type=EventTypeFactory(),
+        )
+
+    def test_api_response_for_event(self):
+        response = self.client.get(f"/api/v3/pages/{self.event_page.id}/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_api_response_for_event_with_null_type(self):
+        event_type = EventType.objects.get(id=self.event_page.event_type.id)
+        event_type.delete()
+        self.event_page.refresh_from_db()
+        response = self.client.get(f"/api/v3/pages/{self.event_page.id}/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["event_type"], None)
+
+    def test_api_response_for_event_with_null_directorate(self):
+        # Add a directorate that relates to the page
+        directorate = DirectorateFactory()
+        self.event_page.related_directorates = [
+            EventDetailPageRelatedDirectorate(
+                source_page=self.event_page, directorate=directorate
+            )
+        ]
+        self.event_page.save()
+        # Check the directorate is there
+        response = self.client.get(f"/api/v3/pages/{self.event_page.id}/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data["related_directorates"][0]["title"], directorate.title
+        )
+
+        # Delete the directorate
+        directorate = Directorate.objects.get(
+            id=self.event_page.related_directorates.first().directorate.id
+        )
+        directorate.delete()
+
+        # Assert there are no related directorates
+        self.assertQuerysetEqual(self.event_page.related_directorates.all(), [])
+        response = self.client.get(f"/api/v3/pages/{self.event_page.id}/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["related_directorates"], [])
+
+
+# TODO
+# The intranet integration depends on the api structure remaining intact.
+# we need to write tests to confirm it fails if changed

--- a/rca/events/tests/test_models.py
+++ b/rca/events/tests/test_models.py
@@ -7,6 +7,19 @@ from wagtail.tests.utils import WagtailPageTests
 
 from rca.editorial.factories import EditorialPageFactory, EditorialTypeFactory
 from rca.editorial.models import EditorialPageTypePlacement
+from rca.events.factories import (
+    EventAvailabilityFactory,
+    EventDetailPageFactory,
+    EventEligibility,
+    EventLocationFactory,
+    EventSeriesFactory,
+    EventTypeFactory,
+)
+from rca.events.models import (
+    EventDetailPage,
+    EventDetailPageRelatedPages,
+    EventIndexPage,
+)
 from rca.guides.factories import GuidePageFactory
 from rca.home.models import HomePage
 from rca.landingpages.factories import (
@@ -15,27 +28,19 @@ from rca.landingpages.factories import (
     InnovationLandingPageFactory,
     ResearchLandingPageFactory,
 )
-from rca.people.factories import DirectorateFactory
-from rca.people.models import Directorate
 from rca.programmes.factories import ProgrammePageFactory
 from rca.research.factories import ResearchCentrePageFactory
 from rca.schools.factories import SchoolPageFactory
 from rca.shortcourses.factories import ShortCoursePageFactory
 from rca.standardpages.models import IndexPage, InformationPage
 
-from .factories import EventDetailPageFactory, EventSeriesFactory, EventTypeFactory
-from .models import (
-    EventDetailPage,
-    EventDetailPageRelatedDirectorate,
-    EventDetailPageRelatedPages,
-    EventIndexPage,
-    EventType,
-)
-
 
 class TestEventDetailPageFactories(TestCase):
     def test_factories(self):
         EventDetailPageFactory()
+        EventLocationFactory()
+        EventAvailabilityFactory()
+        EventEligibility()
 
 
 class EventDetailPageTests(WagtailPageTests):
@@ -275,56 +280,3 @@ class EventDetailPageRelatedContentTests(WagtailPageTests):
             self.make_related_page(self.event_page, self.landing_page_enterprise)
         ]
         self.assertEqual(self.event_page.get_related_pages()["items"][0]["meta"], "")
-
-
-class EventSerializerTests(WagtailPageTests):
-    def setUp(self):
-        self.home_page = HomePage.objects.first()
-        self.event_page = EventDetailPageFactory(
-            parent=self.home_page, event_type=EventTypeFactory(),
-        )
-
-    def test_api_response_for_event(self):
-        response = self.client.get(f"/api/v3/pages/{self.event_page.id}/")
-        self.assertEqual(response.status_code, 200)
-
-    def test_api_response_for_event_with_null_type(self):
-        event_type = EventType.objects.get(id=self.event_page.event_type.id)
-        event_type.delete()
-        self.event_page.refresh_from_db()
-        response = self.client.get(f"/api/v3/pages/{self.event_page.id}/")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["event_type"], None)
-
-    def test_api_response_for_event_with_null_directorate(self):
-        # Add a directorate that relates to the page
-        directorate = DirectorateFactory()
-        self.event_page.related_directorates = [
-            EventDetailPageRelatedDirectorate(
-                source_page=self.event_page, directorate=directorate
-            )
-        ]
-        self.event_page.save()
-        # Check the directorate is there
-        response = self.client.get(f"/api/v3/pages/{self.event_page.id}/")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.data["related_directorates"][0]["title"], directorate.title
-        )
-
-        # Delete the directorate
-        directorate = Directorate.objects.get(
-            id=self.event_page.related_directorates.first().directorate.id
-        )
-        directorate.delete()
-
-        # Assert there are no related directorates
-        self.assertQuerysetEqual(self.event_page.related_directorates.all(), [])
-        response = self.client.get(f"/api/v3/pages/{self.event_page.id}/")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["related_directorates"], [])
-
-
-# TODO
-# The intranet integration depends on the api structure remaining intact.
-# we need to write tests to confirm it fails if changed

--- a/rca/people/factories.py
+++ b/rca/people/factories.py
@@ -2,7 +2,7 @@ import factory
 import wagtail_factories
 from faker import Factory as FakerFactory
 
-from .models import Directorate, StudentIndexPage, StudentPage
+from .models import Directorate, StaffPage, StudentIndexPage, StudentPage
 
 faker = FakerFactory.create()
 
@@ -29,3 +29,12 @@ class StudentIndexPageFactory(wagtail_factories.PageFactory):
 
     title = factory.Faker("text", max_nb_chars=25)
     introduction = factory.Faker("text", max_nb_chars=250)
+
+
+class StaffPageFactory(wagtail_factories.PageFactory):
+    class Meta:
+        model = StaffPage
+
+    title = factory.Faker("text", max_nb_chars=25)
+    first_name = factory.Faker("text", max_nb_chars=25)
+    last_name = factory.Faker("text", max_nb_chars=25)

--- a/rca/people/tests/test_models.py
+++ b/rca/people/tests/test_models.py
@@ -14,6 +14,7 @@ from wagtail_factories import CollectionFactory
 from rca.home.models import HomePage
 from rca.people.factories import (
     DirectorateFactory,
+    StaffPageFactory,
     StudentIndexPageFactory,
     StudentPageFactory,
 )
@@ -27,6 +28,7 @@ class TestStudentPageFactory(TestCase):
         StudentPageFactory()
         StudentIndexPageFactory()
         DirectorateFactory()
+        StaffPageFactory()
 
 
 class TestStudentIndexPage(WagtailPageTests):

--- a/rca/utils/models.py
+++ b/rca/utils/models.py
@@ -212,6 +212,11 @@ class RelatedStaffPageWithManualOptions(Orderable):
             return page.last_name
         return self.surname
 
+    def link_or_page(self):
+        if self.page:
+            return self.page.full_url
+        return self.link
+
     api_fields = [
         APIField("page"),
         APIField("image"),
@@ -220,6 +225,7 @@ class RelatedStaffPageWithManualOptions(Orderable):
         APIField("role"),
         APIField("description"),
         APIField("link"),
+        "link_or_page",
     ]
 
 


### PR DESCRIPTION
ticket [992](https://torchbox.codebasehq.com/projects/rca-website-rebuild/tickets/992)

**Contains https://github.com/torchbox/rca-wagtail-2019/pull/812**

**Summary**
Because the intranet importer [ref](https://git.torchbox.com/rca/intranet.rca.ac.uk/-/blob/3f267c6b4bfbdcda4e9e0b30f25746579dbac40a/inforca/content/sync/importers.py) depends on some custom serializing and data structure in the API response, we want to be sure that if developers change Event or Editorial fields that the tests fail so we don't break the importer