### PR TITLE
Wagtail 2.15

### DIFF
--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -77,7 +77,6 @@ INSTALLED_APPS = [
     "birdbath",
     "django_countries",
     "wagtail.contrib.modeladmin",
-    "wagtail.contrib.postgres_search",
     "wagtail.contrib.settings",
     "wagtail.contrib.search_promotions",
     "wagtail.contrib.forms",
@@ -194,9 +193,7 @@ else:
 # Search
 # https://docs.wagtail.io/en/latest/topics/search/backends.html
 
-WAGTAILSEARCH_BACKENDS = {
-    "default": {"BACKEND": "wagtail.contrib.postgres_search.backend"}
-}
+WAGTAILSEARCH_BACKENDS = {"default": {"BACKEND": "wagtail.search.backends.database"}}
 
 
 # Password validation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==3.2.6
-wagtail==2.14.1
+wagtail==2.15.1
 psycopg2==2.8.6
 wagtail-django-recaptcha==1.0
 django-pattern-library==0.3.0


### PR DESCRIPTION
Support ticket: https://projects.torchbox.com/projects/support-team/tickets/273
Client ticket: https://projects.torchbox.com/projects/hosting-application-support/tickets/16
2.15 upgrade notes: https://docs.wagtail.io/en/latest/releases/2.15.html

This MR upgrades wagtail from 2.14.1 to 2.15.1 (targeting approved branch upgrade/wagtail-2.14)

I've update the searchbackend although it looks like [search was removed recently](https://github.com/torchbox/rca-wagtail-2019/commit/d6fa7dc608bfc4636b64c1cb3b04f2141f7360d2) so this change shouldn't require running update_index and is superficial but is nice to keep the code up to date.