### PR TITLE
Add functionality to only have a single filter option in filter takeover

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/filter-tab-options/filter-tab-options.html
+++ b/rca/project_styleguide/templates/patterns/molecules/filter-tab-options/filter-tab-options.html
@@ -20,7 +20,7 @@
             {% for option in item.options %}
                 <div class="filter-tab-options__item layout__span-two">
                     <input class="filter-tab-options__checkbox" type="checkbox" id="filter-{{ item.filter_name }}-{{ option.id }}" name="{{ item.filter_name }}" value="{{ option.id }}" {% if option.active %}checked{% endif %} />
-                    <label class="filter-tab-options__link body body--one {% if option.active %}selected{% endif %}" for="filter-{{ item.filter_name }}-{{ option.id }}" data-filter-option>{{ option.title }} {{ option.suffix }}</label>
+                    <label class="filter-tab-options__link body body--one {% if option.active %}selected{% endif %}" for="filter-{{ item.filter_name }}-{{ option.id }}" data-filter-option {% if single_filter_only %}data-filter-single{% endif %}>{{ option.title }} {{ option.suffix }}</label>
                 </div>
             {% endfor %}
         </div>

--- a/rca/project_styleguide/templates/patterns/pages/scholarships/scholarships_listing_page.html
+++ b/rca/project_styleguide/templates/patterns/pages/scholarships/scholarships_listing_page.html
@@ -121,18 +121,18 @@
                                 {% for item in filters.items %}
                                     {% if item.queryset %}
                                         <div class="filter-takeover__tab-content tabs__panel tabs__panel--hidden js-tab-panel" id="{{ item.tab_title|slugify }}" role="tabpanel" aria-labelledby="tab-{{ item.tab_title|slugify }}">
-                                            {% include "patterns/molecules/filter-tab-options/filter-tab-options.html" %}
+                                            {% include "patterns/molecules/filter-tab-options/filter-tab-options.html" with single_filter_only=True %}
                                         </div>
                                     {% endif %}
                                 {% endfor %}
                             </div>
                         </div>
                     </div>
-                        
+
                     {% comment %}
 
                     Hidden until implemented to avoid confusion during testing.
-                    
+
                     <div class="section__row grid">
                         <div class="layout__start-one layout__span-two layout__@large-start-two layout__@large-span-three">
                             <p class="body body--one"><b>Scholarship results showing for ***Design*** programme</b></p>

--- a/rca/static_src/javascript/components/project-filters.js
+++ b/rca/static_src/javascript/components/project-filters.js
@@ -247,6 +247,13 @@ class ProjectFilters {
             }
             // Check if reset needs to show
             this.checkResetStatus();
+
+            // If this is a single option form, then submit the form
+            if (e.target.hasAttribute('data-filter-single')) {
+                this.closeProjectFilters();
+                this.body.classList.remove('project-filters-mobile');
+                document.getElementById('results').submit();
+            }
         });
 
         // Categories


### PR DESCRIPTION
Javascript to allow us to specify that only one filter should be selectable - the form should submit when a filter item is chosen.
