### PR TITLE
Making 4th+ footer link wrap onto new line

### DIFF
--- a/rca/static_src/sass/layout/_footer.scss
+++ b/rca/static_src/sass/layout/_footer.scss
@@ -67,6 +67,7 @@
             grid-column-start: 2;
             grid-column-end: 5;
             display: flex;
+            flex-wrap: wrap;
             flex-direction: row;
         }
     }


### PR DESCRIPTION
Small tweak to ensure when more than 3 items are added to the footer that they wrap:

![Screenshot 2022-01-24 at 14 13 51](https://user-images.githubusercontent.com/298766/150798886-2de83799-9b29-40c3-bb53-eb684f5df718.png)
![Screenshot 2022-01-24 at 14 13 45](https://user-images.githubusercontent.com/298766/150798893-94058ba3-c193-4f60-a653-2688d9ffb6fb.png)
![Screenshot 2022-01-24 at 14 13 54](https://user-images.githubusercontent.com/298766/150798902-6a26d7ba-021b-463e-bc49-e4aeaeba7835.png)
