### PR TITLE
Support-370: EventDetailPage add to calendar link fix

### DIFF
--- a/rca/events/models.py
+++ b/rca/events/models.py
@@ -763,8 +763,8 @@ class EventDetailPage(ContactFieldsMixin, BasePage):
             # Get date
             date = self.start_date + datetime.timedelta(days=day)
             # Get times
-            start_datetime = datetime.datetime.combine(date, self.start_date.time())
-            end_datetime = datetime.datetime.combine(date, self.end_date.time())
+            start_datetime = datetime.datetime.combine(date, self.start_time)
+            end_datetime = datetime.datetime.combine(date, self.end_time)
 
             # Get a location
             location = getattr(self, "location", None)

--- a/rca/events/models.py
+++ b/rca/events/models.py
@@ -739,13 +739,14 @@ class EventDetailPage(ContactFieldsMixin, BasePage):
         """
         Escapes special characters in long form text fields for ics records.
         """
-        string.replace('"', '\\"')
-        string.replace("\\", "\\\\")
-        string.replace(",", "\\,")
-        string.replace(":", "\\:")
-        string.replace(";", "\\;")
-        string.replace("\n", "\\n")
-        return string
+        if string:
+            string.replace('"', '\\"')
+            string.replace("\\", "\\\\")
+            string.replace(",", "\\,")
+            string.replace(":", "\\:")
+            string.replace(";", "\\;")
+            string.replace("\n", "\\n")
+        return string or ""
 
     def get_ics_record(self):
         # Begin event


### PR DESCRIPTION
Ticket: https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2435

Root Issue: Trying to get time from the Date object. 

EventDetailPage has `start_time` and `end_time` fields, we need to get the time information from those fields.