### PR TITLE
No division without calc (due to deprecation) fixs

### DIFF
--- a/rca/static_src/sass/base/_typography.scss
+++ b/rca/static_src/sass/base/_typography.scss
@@ -3,18 +3,17 @@
 \*------------------------------------*/
 
 html {
-    font-size: (map-get($small-font-sizes, xs) / 16px) * 100%;
+    font-size: calc((map-get($small-font-sizes, xs) / 16px) * 100%);
+    line-height: 1.4;
+    color: $color--primary;
 
     @include media-query(medium) {
-        font-size: (map-get($medium-font-sizes, xs) / 16px) * 100%;
+        font-size: calc((map-get($medium-font-sizes, xs) / 16px) * 100%);
     }
 
     @include media-query(large) {
-        font-size: (map-get($large-font-sizes, xs) / 16px) * 100%;
+        font-size: calc((map-get($large-font-sizes, xs) / 16px) * 100%);
     }
-
-    line-height: 1.4;
-    color: $color--primary;
 }
 
 h1,

--- a/rca/static_src/sass/components/_accordion.scss
+++ b/rca/static_src/sass/components/_accordion.scss
@@ -214,7 +214,7 @@
     }
 
     &__preview-text {
-        margin: ($gutter / 2) 0 0;
+        margin: ($gutter * 0.5) 0 0;
         transition: color $transition;
         max-width: 65%;
         font-weight: $weight--normal;

--- a/rca/static_src/sass/components/_anchor-nav-item.scss
+++ b/rca/static_src/sass/components/_anchor-nav-item.scss
@@ -1,5 +1,5 @@
 .anchor-nav-item {
-    margin-bottom: ($gutter / 2);
+    margin-bottom: ($gutter * 0.5);
 
     &__link {
         @include underline-hover();

--- a/rca/static_src/sass/components/_back-link.scss
+++ b/rca/static_src/sass/components/_back-link.scss
@@ -23,7 +23,7 @@
 
     &__text {
         display: none;
-        margin-left: ($gutter / 4);
+        margin-left: ($gutter * 0.25);
 
         @include media-query(medium) {
             display: block;

--- a/rca/static_src/sass/components/_booking-bar.scss
+++ b/rca/static_src/sass/components/_booking-bar.scss
@@ -35,7 +35,7 @@
         grid-column: 1 / span 1;
         padding-top: ($gutter);
         padding-bottom: ($gutter);
-        padding-right: ($gutter / 2);
+        padding-right: ($gutter * 0.5);
 
         @include media-query(medium) {
             display: block;

--- a/rca/static_src/sass/components/_breadcrumb.scss
+++ b/rca/static_src/sass/components/_breadcrumb.scss
@@ -36,8 +36,8 @@
         &::after {
             display: inline-block;
             content: '/';
-            padding-left: ($gutter / 2);
-            margin-right: ($gutter / 2);
+            padding-left: ($gutter * 0.5);
+            margin-right: ($gutter * 0.5);
         }
     }
 

--- a/rca/static_src/sass/components/_burger.scss
+++ b/rca/static_src/sass/components/_burger.scss
@@ -7,7 +7,7 @@
     &__toggle-label {
         @include font-size(xxxs);
         color: $color--white;
-        margin-left: ($gutter / 2);
+        margin-left: ($gutter * 0.5);
     }
 
     &__toggle-icon {
@@ -26,12 +26,12 @@
             margin-left: 0;
 
             @include media-query(medium) {
-                margin-left: ($gutter / 2);
+                margin-left: ($gutter * 0.5);
             }
         }
 
         #{$root}__toggle-icon {
-            margin-bottom: ($grid / 2);
+            margin-bottom: ($grid * 0.5);
 
             @include media-query(medium) {
                 margin-bottom: 0;
@@ -44,7 +44,7 @@
         flex-direction: row;
 
         #{$root}__toggle-label {
-            margin-left: ($gutter / 2);
+            margin-left: ($gutter * 0.5);
         }
 
         #{$root}__toggle-icon {

--- a/rca/static_src/sass/components/_card.scss
+++ b/rca/static_src/sass/components/_card.scss
@@ -291,12 +291,12 @@
     &__meta {
         font-size: map-get($small-font-sizes, xxxs);
         text-transform: uppercase;
-        margin-bottom: ($gutter / 4);
+        margin-bottom: ($gutter * 0.25);
     }
 
     &__heading {
         @include font-size(s);
-        margin-bottom: ($gutter / 2);
+        margin-bottom: ($gutter * 0.5);
         line-height: $line-height-large;
 
         #{$root}__link & {
@@ -346,7 +346,7 @@
 
         @include media-query(medium) {
             @include font-size(xxs);
-            margin-bottom: ($gutter / 4);
+            margin-bottom: ($gutter * 0.25);
         }
     }
 
@@ -590,7 +590,7 @@
 
             #{$root}__description {
                 @include media-query(large) {
-                    margin-bottom: ($gutter / 2);
+                    margin-bottom: ($gutter * 0.5);
                 }
             }
 
@@ -701,7 +701,7 @@
                 left: 0;
                 margin: 0;
                 min-width: ($gutter * 4);
-                padding: ($gutter / 4) ($gutter / 2) ($gutter / 4) 0;
+                padding: ($gutter * 0.25) ($gutter * 0.5) ($gutter * 0.25) 0;
             }
         }
 

--- a/rca/static_src/sass/components/_categories-tablist.scss
+++ b/rca/static_src/sass/components/_categories-tablist.scss
@@ -64,7 +64,7 @@
                 display: block;
                 position: absolute;
                 top: 0;
-                right: -($gutter / 4);
+                right: -($gutter * 0.25);
                 width: 6px;
                 height: 6px;
                 border-radius: 50%;
@@ -203,7 +203,7 @@
                         display: block;
                         position: absolute;
                         top: 0;
-                        right: -($gutter / 2);
+                        right: -($gutter * 0.5);
                         width: 6px;
                         height: 6px;
                         border-radius: 50%;

--- a/rca/static_src/sass/components/_exceptional-cta.scss
+++ b/rca/static_src/sass/components/_exceptional-cta.scss
@@ -8,7 +8,7 @@
     margin-top: ($gutter * 3);
     border: 0;
     border-top: 4px solid $color--tertiary;
-    padding: ($gutter / 2) ($gutter * 3) 0 0;
+    padding: ($gutter * 0.5) ($gutter * 3) 0 0;
     background-color: transparent;
     width: 100%;
     text-align: left;

--- a/rca/static_src/sass/components/_featured-alumni.scss
+++ b/rca/static_src/sass/components/_featured-alumni.scss
@@ -54,7 +54,7 @@
         @include font-size(xxs);
 
         li {
-            margin-bottom: ($gutter / 4);
+            margin-bottom: ($gutter * 0.25);
         }
     }
 

--- a/rca/static_src/sass/components/_fees.scss
+++ b/rca/static_src/sass/components/_fees.scss
@@ -37,7 +37,7 @@
         }
 
         &--title {
-            padding: $gutter 0 ($gutter / 2);
+            padding: $gutter 0 ($gutter * 0.5);
             grid-column: 1 / span 2;
 
             @include media-query(large) {

--- a/rca/static_src/sass/components/_filter-bar.scss
+++ b/rca/static_src/sass/components/_filter-bar.scss
@@ -14,10 +14,10 @@
     &--small {
         border-width: 0 0 1px;
         border-style: solid;
-        padding: ($gutter / 2) $gutter;
+        padding: ($gutter * 0.5) $gutter;
 
         @include media-query(medium) {
-            padding: ($gutter / 2) ($gutter * 3);
+            padding: ($gutter * 0.5) ($gutter * 3);
         }
 
         @include media-query(large) {

--- a/rca/static_src/sass/components/_filter-tab-options.scss
+++ b/rca/static_src/sass/components/_filter-tab-options.scss
@@ -152,7 +152,7 @@
     &__button {
         background-color: transparent;
         border: 0;
-        padding: ($gutter / 2) 0 0;
+        padding: ($gutter * 0.5) 0 0;
         font-family: $font--secondary;
         cursor: pointer;
         margin-left: auto;
@@ -254,7 +254,7 @@
             bottom: 0;
             left: 0;
             width: 100%;
-            padding: ($gutter / 2) $gutter;
+            padding: ($gutter * 0.5) $gutter;
             border-color: $color--grid-line-dark;
         }
 

--- a/rca/static_src/sass/components/_form-item.scss
+++ b/rca/static_src/sass/components/_form-item.scss
@@ -250,7 +250,7 @@
         }
 
         label {
-            margin-left: ($gutter / 2);
+            margin-left: ($gutter * 0.5);
             margin-bottom: 0 !important;
         }
     }
@@ -269,7 +269,7 @@
         }
 
         input {
-            margin-right: ($gutter / 2);
+            margin-right: ($gutter * 0.5);
         }
 
         li {
@@ -286,7 +286,7 @@
     &--select_multiple,
     &--select,
     &--lazy_select {
-        padding-top: ($gutter / 2);
+        padding-top: ($gutter * 0.5);
 
         input {
             &:focus {
@@ -336,7 +336,7 @@
     label,
     legend {
         display: block;
-        margin-bottom: ($gutter / 4);
+        margin-bottom: ($gutter * 0.25);
         cursor: pointer;
     }
 
@@ -406,7 +406,7 @@
     &__help {
         @include font-size(xxxs);
         margin-bottom: $form-bottom-margin;
-        margin-top: ($gutter / 4);
+        margin-top: ($gutter * 0.25);
     }
 
     &__required {

--- a/rca/static_src/sass/components/_hero-action-pane.scss
+++ b/rca/static_src/sass/components/_hero-action-pane.scss
@@ -87,7 +87,7 @@
         position: relative;
         width: 170px;
         display: block;
-        padding-top: ($gutter / 2);
+        padding-top: ($gutter * 0.5);
         pointer-events: auto;
 
         @include media-query(medium) {
@@ -130,8 +130,8 @@
     &__cta-heading {
         @include font-size(xs);
         color: currentColor;
-        margin-bottom: ($gutter / 2);
-        padding-right: ($gutter / 2);
+        margin-bottom: ($gutter * 0.5);
+        padding-right: ($gutter * 0.5);
 
         @include media-query(medium) {
             padding-right: $gutter;
@@ -141,13 +141,13 @@
     &__cta-sub-heading {
         @include font-size(xxxs);
         color: currentColor;
-        padding-right: ($gutter / 2);
+        padding-right: ($gutter * 0.5);
     }
 
     &__cta-icon {
         position: absolute;
         left: 161px;
-        top: ($gutter / 2);
+        top: ($gutter * 0.5);
         transition: transform $transition;
         transform: rotate(-45deg) translate3d(0, 0, 0);
 

--- a/rca/static_src/sass/components/_image-caption-link.scss
+++ b/rca/static_src/sass/components/_image-caption-link.scss
@@ -72,7 +72,7 @@
         }
 
         #{$root}__caption-text {
-            margin-bottom: -($gutter / 2);
+            margin-bottom: -($gutter * 0.5);
             flex: 1;
             max-width: 60%;
 
@@ -83,7 +83,7 @@
     }
 
     &__caption-icon {
-        margin-right: ($gutter / 2);
+        margin-right: ($gutter * 0.5);
     }
 
     &__image-icon {

--- a/rca/static_src/sass/components/_image-video-block.scss
+++ b/rca/static_src/sass/components/_image-video-block.scss
@@ -86,7 +86,7 @@
         display: none;
         text-transform: uppercase;
         grid-column: 1 / span 2;
-        margin-bottom: ($gutter / 2);
+        margin-bottom: ($gutter * 0.5);
         letter-spacing: 0.05em;
 
         @include media-query(medium) {
@@ -111,7 +111,7 @@
         &--meta-heading {
             font-family: $font--secondary;
             font-weight: $weight--medium;
-            margin-bottom: ($gutter / 2);
+            margin-bottom: ($gutter * 0.5);
         }
 
         @include media-query(medium) {

--- a/rca/static_src/sass/components/_job-titles.scss
+++ b/rca/static_src/sass/components/_job-titles.scss
@@ -6,6 +6,6 @@
     }
 
     &__department {
-        margin-top: ($gutter / 2);
+        margin-top: ($gutter * 0.5);
     }
 }

--- a/rca/static_src/sass/components/_key-details.scss
+++ b/rca/static_src/sass/components/_key-details.scss
@@ -54,7 +54,7 @@
     &--centre {
         #{$root}__meta {
             // Allow for mobile link underline above it
-            margin-top: ($gutter / 4);
+            margin-top: ($gutter * 0.25);
 
             @include media-query(large) {
                 margin-top: 0;
@@ -136,7 +136,7 @@
     }
 
     &__sub-heading {
-        margin-bottom: ($gutter / 2);
+        margin-bottom: ($gutter * 0.5);
     }
 
     &__list {
@@ -149,7 +149,7 @@
     }
 
     &__list-item {
-        margin-bottom: ($gutter / 2.25);
+        margin-bottom: calc($gutter / 2.25);
 
         &--tight {
             line-height: $line-height-tight;

--- a/rca/static_src/sass/components/_logo-card.scss
+++ b/rca/static_src/sass/components/_logo-card.scss
@@ -39,7 +39,7 @@
         left: 0;
         right: 0;
         color: $color--black;
-        padding: ($gutter / 4) ($gutter / 2);
+        padding: ($gutter * 0.25) ($gutter * 0.5);
         font-size: map-get($small-font-sizes, xxxs);
 
         @include media-query(medium) {

--- a/rca/static_src/sass/components/_modal-launcher.scss
+++ b/rca/static_src/sass/components/_modal-launcher.scss
@@ -19,7 +19,7 @@
         position: relative;
         font-family: $font--secondary;
         color: $color--white;
-        padding: ($gutter / 2) $gutter ($gutter / 2) 0;
+        padding: ($gutter * 0.5) $gutter ($gutter * 0.5) 0;
     }
 
     &__icon-container {

--- a/rca/static_src/sass/components/_modal.scss
+++ b/rca/static_src/sass/components/_modal.scss
@@ -27,7 +27,7 @@
     }
 
     &__header {
-        margin-top: ($gutter / 2);
+        margin-top: ($gutter * 0.5);
         margin-bottom: ($gutter * 2);
 
         @include media-query(medium) {
@@ -53,7 +53,7 @@
     &__close-label {
         display: none;
         font-family: $font--secondary;
-        margin-right: ($gutter / 4);
+        margin-right: ($gutter * 0.25);
         pointer-events: none;
 
         @include media-query(large) {

--- a/rca/static_src/sass/components/_no-results.scss
+++ b/rca/static_src/sass/components/_no-results.scss
@@ -1,6 +1,6 @@
 .no-results {
     &__heading {
-        margin-bottom: ($gutter / 2);
+        margin-bottom: ($gutter * 0.5);
     }
 
     &__info {

--- a/rca/static_src/sass/components/_outdated-banner.scss
+++ b/rca/static_src/sass/components/_outdated-banner.scss
@@ -26,7 +26,7 @@
     }
 
     &__heading {
-        margin-bottom: ($gutter / 3);
+        margin-bottom: calc($gutter / 3);
         font-family: $font--secondary;
         font-weight: $weight--medium;
     }

--- a/rca/static_src/sass/components/_pagination.scss
+++ b/rca/static_src/sass/components/_pagination.scss
@@ -1,7 +1,7 @@
 .pagination {
     $root: &;
     // Space either side of pagination items
-    $spacing: ($gutter / 2);
+    $spacing: ($gutter * 0.5);
 
     &__container {
         display: flex;

--- a/rca/static_src/sass/components/_pathways.scss
+++ b/rca/static_src/sass/components/_pathways.scss
@@ -6,6 +6,6 @@
     }
 
     &__items {
-        padding-top: ($gutter / 2);
+        padding-top: ($gutter * 0.5);
     }
 }

--- a/rca/static_src/sass/components/_profile-detail.scss
+++ b/rca/static_src/sass/components/_profile-detail.scss
@@ -34,7 +34,7 @@
     }
 
     &__header {
-        margin-bottom: ($gutter / 4);
+        margin-bottom: ($gutter * 0.25);
     }
 
     &__heading {
@@ -49,10 +49,10 @@
 
     &__body {
         font-family: $font--primary;
-        margin-bottom: ($gutter / 2);
+        margin-bottom: ($gutter * 0.5);
 
         @include media-query(medium) {
-            margin-bottom: ($gutter / 4);
+            margin-bottom: ($gutter * 0.25);
         }
     }
 

--- a/rca/static_src/sass/components/_profile-teaser.scss
+++ b/rca/static_src/sass/components/_profile-teaser.scss
@@ -62,7 +62,7 @@
         margin: 0;
 
         &--first {
-            margin-top: ($gutter / 4);
+            margin-top: ($gutter * 0.25);
         }
     }
 

--- a/rca/static_src/sass/components/_quote.scss
+++ b/rca/static_src/sass/components/_quote.scss
@@ -12,7 +12,7 @@
     }
 
     &__job-title {
-        margin-left: ($gutter / 4);
+        margin-left: ($gutter * 0.25);
     }
 
     .carousel--square & {

--- a/rca/static_src/sass/components/_related-content.scss
+++ b/rca/static_src/sass/components/_related-content.scss
@@ -31,7 +31,7 @@
 
         #{$root}__copy {
             grid-column: 1 / span 2;
-            padding-top: ($gutter / 4);
+            padding-top: ($gutter * 0.25);
 
             @include media-query(medium) {
                 grid-column: 2 / span 1;
@@ -112,15 +112,15 @@
         }
 
         #{$root}__title {
-            margin-bottom: ($gutter / 2);
+            margin-bottom: ($gutter * 0.5);
 
             @include media-query(medium) {
-                margin-bottom: ($gutter / 4);
+                margin-bottom: ($gutter * 0.25);
             }
         }
 
         #{$root}__degree {
-            margin-bottom: ($gutter / 2);
+            margin-bottom: ($gutter * 0.5);
 
             @include media-query(medium) {
                 margin-bottom: $gutter;
@@ -188,7 +188,7 @@
 
     &__copy {
         grid-column: 1 / span 2;
-        padding-bottom: ($gutter / 0.75);
+        padding-bottom: calc($gutter / 0.75);
 
         &:last-of-type {
             border-bottom: 0;
@@ -250,8 +250,8 @@
     }
 
     &__title {
-        margin-bottom: ($gutter / 4);
-        margin-right: ($gutter / 4);
+        margin-bottom: ($gutter * 0.25);
+        margin-right: ($gutter * 0.25);
 
         @include media-query(medium) {
             margin-right: 0;
@@ -259,7 +259,7 @@
     }
 
     &__degree {
-        margin-bottom: ($gutter / 4);
+        margin-bottom: ($gutter * 0.25);
     }
 
     &__action {

--- a/rca/static_src/sass/components/_reset.scss
+++ b/rca/static_src/sass/components/_reset.scss
@@ -17,7 +17,7 @@
     }
 
     &__icon {
-        margin-right: ($gutter / 4);
+        margin-right: ($gutter * 0.25);
         fill: currentColor;
     }
 

--- a/rca/static_src/sass/components/_rich-text.scss
+++ b/rca/static_src/sass/components/_rich-text.scss
@@ -106,7 +106,7 @@
             @include font-size(s);
             border-width: 0 0 1px;
             border-style: solid;
-            padding-bottom: ($gutter / 2);
+            padding-bottom: ($gutter * 0.5);
             margin-bottom: $gutter;
         }
 

--- a/rca/static_src/sass/components/_schools.scss
+++ b/rca/static_src/sass/components/_schools.scss
@@ -5,7 +5,7 @@
         top: -($gutter);
 
         @include media-query(medium) {
-            top: -($gutter / 2);
+            top: -($gutter * 0.5);
         }
 
         @include media-query(large) {

--- a/rca/static_src/sass/components/_scroll.scss
+++ b/rca/static_src/sass/components/_scroll.scss
@@ -6,7 +6,7 @@
     &__label {
         @include font-size(xxxs);
         display: none;
-        padding-bottom: ($gutter / 4);
+        padding-bottom: ($gutter * 0.25);
 
         @include media-query(medium) {
             display: block;

--- a/rca/static_src/sass/components/_search-result.scss
+++ b/rca/static_src/sass/components/_search-result.scss
@@ -32,7 +32,7 @@
 
         @include media-query(medium) {
             padding-top: $padding-top-medium;
-            padding-bottom: ($gutter / 4);
+            padding-bottom: ($gutter * 0.25);
         }
 
         @include media-query(large) {
@@ -60,7 +60,7 @@
     }
 
     &__editor-pick {
-        padding-top: ($gutter / 4);
+        padding-top: ($gutter * 0.25);
     }
 
     &__summary {

--- a/rca/static_src/sass/components/_search-toggle.scss
+++ b/rca/static_src/sass/components/_search-toggle.scss
@@ -10,7 +10,7 @@
 
     &__label {
         @include font-size(xxxs);
-        margin-left: ($gutter / 2);
+        margin-left: ($gutter * 0.5);
         color: $color--white;
     }
 

--- a/rca/static_src/sass/components/_search.scss
+++ b/rca/static_src/sass/components/_search.scss
@@ -18,7 +18,7 @@
         border-radius: 0;
         width: 100%;
         border-bottom: 1px inset $color--white;
-        padding: ($gutter / 2) ($gutter * 1.5) ($gutter / 2) ($gutter / 2);
+        padding: ($gutter * 0.5) ($gutter * 1.5) ($gutter * 0.5) ($gutter * 0.5);
         transition: border-width $transition-cubic,
             border-color $transition-cubic;
 

--- a/rca/static_src/sass/components/_section.scss
+++ b/rca/static_src/sass/components/_section.scss
@@ -512,10 +512,10 @@
         }
 
         &--first-extra-small {
-            padding-top: ($gutter / 4);
+            padding-top: ($gutter * 0.25);
 
             @include media-query(large) {
-                padding-top: ($gutter / 2);
+                padding-top: ($gutter * 0.5);
             }
         }
 

--- a/rca/static_src/sass/components/_skip-link.scss
+++ b/rca/static_src/sass/components/_skip-link.scss
@@ -12,7 +12,7 @@
         left: 0;
         color: $color--black;
         background-color: $color--white;
-        padding: ($grid / 2) $grid;
+        padding: ($grid * 0.5) $grid;
         white-space: nowrap;
 
         &:focus {

--- a/rca/static_src/sass/components/_slide.scss
+++ b/rca/static_src/sass/components/_slide.scss
@@ -75,7 +75,7 @@
 
     &__author-course {
         @include font-size(xxs);
-        margin-top: ($gutter / 4);
+        margin-top: ($gutter * 0.25);
     }
 
     &__link {

--- a/rca/static_src/sass/components/_stat-block.scss
+++ b/rca/static_src/sass/components/_stat-block.scss
@@ -176,7 +176,7 @@
     }
 
     &__body {
-        margin: ($gutter / 2) 0 0;
+        margin: ($gutter * 0.5) 0 0;
         max-width: 270px;
 
         @include media-query(medium) {

--- a/rca/static_src/sass/components/_tab-nav.scss
+++ b/rca/static_src/sass/components/_tab-nav.scss
@@ -42,7 +42,7 @@
         flex-wrap: nowrap;
         flex-direction: row;
         grid-column: 1 / span 2;
-        padding: ($gutter / 2) $gutter;
+        padding: ($gutter * 0.5) $gutter;
         overflow-x: auto;
 
         @include media-query(medium) {

--- a/rca/static_src/sass/components/_title-area.scss
+++ b/rca/static_src/sass/components/_title-area.scss
@@ -32,7 +32,7 @@
     }
 
     &__heading {
-        margin-bottom: ($gutter / 2);
+        margin-bottom: ($gutter * 0.5);
     }
 
     &__meta {
@@ -151,7 +151,7 @@
         // However there are viewports right after the "large" width where this would cause the text to overlap.
         // In those cases, we align the text with the bottom of the line instead, so there is no overlap.
         $xxxl-font: map-get($large-font-sizes, xxxl);
-        $heading-line-height: $xxxl-font * ($line-height-large / 100%);
+        $heading-line-height: calc($xxxl-font * ($line-height-large / 100%));
         $heading-line-2-bottom: $heading-line-height * 2;
         // We want the text to be aligned with the top of lowercase letters on the line, so need extra space.
         $heading-line-2-top: $heading-line-height * 1 + 23px;

--- a/rca/static_src/sass/layout/_header.scss
+++ b/rca/static_src/sass/layout/_header.scss
@@ -360,8 +360,8 @@
     // Show when scrolling back up
     .headroom--pinned.headroom--not-top & {
         #{$root}__container {
-            padding-top: ($gutter / 4);
-            padding-bottom: ($gutter / 4);
+            padding-top: ($gutter * 0.25);
+            padding-bottom: ($gutter * 0.25);
         }
     }
 }


### PR DESCRIPTION
Search and replace for maths including division without the calc/math prefix to ensure our code still works when we eventually move to Dart Sass 2.0.0