### PR TITLE
Feature/2436 booking bar fix

### DIFF
--- a/rca/project_styleguide/templates/patterns/pages/events/event_detail--limited.html
+++ b/rca/project_styleguide/templates/patterns/pages/events/event_detail--limited.html
@@ -1,0 +1,1 @@
+{% extends "patterns/pages/events/event_detail.html" %}

--- a/rca/project_styleguide/templates/patterns/pages/events/event_detail--limited.yaml
+++ b/rca/project_styleguide/templates/patterns/pages/events/event_detail--limited.yaml
@@ -1,0 +1,68 @@
+context:
+  hero_image: true
+  page:
+    title: 'SoAH Research Presents | Entanglement: just dreaming (the worlds)'
+    full_url: http://www.rca.ac.uk/event/my-awesome-event/
+    get_ancestors:
+      - is_root: false
+        depth: 2
+        title: News & Events
+      - is_root: false
+        depth: 3
+        title: Events
+    introduction: '<p>Situated within the Royal College of Art, a world-leading art and design institution, the programme encourages interdisciplinary and cross-disciplinary research projects in…</p>'
+    event_date: '13 December 2020'
+    event_startDate: !!timestamp '2020-12-13 2:00:00+01:00'
+    event_endDate: !!timestamp '2020-12-16 2:00:00+01:00'
+    event_time: 5pm – 8pm
+    timezone: GMT +1
+    location: Online
+    who_can_attend: Open to all
+    event_type: Exhibition
+    schedule: true
+    add_to_calendar: true
+    read_time: 10 mins
+    price: false
+    past: false
+    show_booking_bar: true
+    manual_registration_url: '#'
+    body:
+      - dummy
+    partners: false
+    staff_link: false
+    inline_cta: false
+    contact: true
+    contact_model_image: false
+    contact_model_text: false
+    series:
+      title: Talks
+      introduction: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.
+  speakers:
+    - { name: 'Beth Hughes', role: 'Head of Programmes', link: '#' }
+    - { name: 'Beth Hughes', role: 'Head of Programmes', link: '#' }
+    - { name: 'Beth Hughes', role: 'Head of Programmes', link: '#' }
+  series_events: false
+  related_staff:
+    view_more_link: false
+  booking_bar:
+    message: 'Free event | Online | Tickets still available'
+    action: 'Book now'
+  related_pages: false
+
+tags:
+  include_block:
+    block:
+      template_name: 'patterns/_pattern_library_only/streamfield/event_streamfield.html'
+  image:
+    hero_image fill-320x285 as image_small:
+      target_var: image_small
+      raw:
+        url: '//placekitten.com/320/285'
+    hero_image fill-768x530 as image_medium:
+      target_var: image_medium
+      raw:
+        url: '//placekitten.com/768/530'
+    hero_image fill-1440x530 as image_large:
+      target_var: image_large
+      raw:
+        url: '//placekitten.com/1440/530'

--- a/rca/project_styleguide/templates/patterns/pages/events/event_detail.html
+++ b/rca/project_styleguide/templates/patterns/pages/events/event_detail.html
@@ -36,7 +36,7 @@
                 {% endif %}
             </div>
 
-            {% if page.past %}
+            {% if not page.show_booking_bar or page.past %}
             <div class="section__notch">
                 <div class="section__notch-fill section__notch-fill--third-col"></div>
             </div>
@@ -52,7 +52,7 @@
 
             <section class="section bg bg--light">
 
-                <div class="section__row {% if page.past %}section__row--first{% else %}section__row--first-small{% endif %} grid">
+                <div class="section__row {% if page.past %}section__row--first{% else %}section__row--first-small{% endif %} section__row--last grid">
 
                     <div class="layout__start-one layout__span-two layout__@large-span-one">
                         {% include "patterns/molecules/key-details/key-details--event.html" %}

--- a/rca/project_styleguide/templates/patterns/pages/events/event_detail.html
+++ b/rca/project_styleguide/templates/patterns/pages/events/event_detail.html
@@ -139,7 +139,7 @@
             </section>
             {% endif %}
 
-            <section class="section bg bg--dark">
+            <section class="section bg bg--dark booking-bar-last-item">
                 {% if series_events %}
                     <div class="in-series section__row section__row--first {% if not related_pages.items %}section__row--last-large{% endif %}">
                         {% include "patterns/organisms/index-module/index-module.html" with items=series_events title="In the series" introduction=page.series.introduction %}
@@ -153,7 +153,7 @@
                 {% endif %}
 
                 {% if page.contact_model_image or page.contact_model_text or page.contact_model_email or page.contact_model_url or page.contact_model_form %}
-                    <div class="section__row section__row--first booking-bar-last-item">
+                    <div class="section__row section__row--first">
                         {% include "patterns/organisms/contact/contact.html" with heading=page.contact_model_title text=page.contact_model_text image=page.contact_model_image %}
                     </div>
                 {% endif %}


### PR DESCRIPTION
Fixing space left under the booking bar when optional fields are not filled in.

An additional event template has been added to ensure things like this aren't missed in the future.

The class that adds the extra space was previously applied to an optional element, this has now been moved to a div that persists.

Ticket:
https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2436

Staging:
https://rca-development.herokuapp.com/pattern-library/render-pattern/patterns/pages/events/event_detail--limited.html

<details>
<summary>Screenshots + </summary>

![before](https://user-images.githubusercontent.com/298766/177141575-cf288dcb-04c4-4f67-9b71-abc7321c6df4.png)

![after](https://user-images.githubusercontent.com/298766/177141569-bfc4c2c0-dd46-44dc-9fd8-63147606ad29.png)

</details>