### PR TITLE
Making results title a h2 on listing pages

### DIFF
--- a/rca/project_styleguide/templates/patterns/pages/project/project_listing.html
+++ b/rca/project_styleguide/templates/patterns/pages/project/project_listing.html
@@ -103,11 +103,11 @@
 
                 {% if results %}
                     <div class="section__row section__row--first-small section__row--last-small grid">
-                        <div class="results-total heading heading--four layout__start-one layout__span-two layout__@large-start-two">
+                        <h2 class="results-total heading heading--four layout__start-one layout__span-two layout__@large-start-two">
                             <span class="results-total__anchor" id="results"></span>
                             <span class="results-total__type">Results</span>
                             <span class="results-total__number">{{ result_count }}</span>
-                        </div>
+                        </h2>
                     </div>
                 {% endif %}
 

--- a/rca/project_styleguide/templates/patterns/pages/staff/staff_index.html
+++ b/rca/project_styleguide/templates/patterns/pages/staff/staff_index.html
@@ -87,11 +87,11 @@
 
                 {% if results %}
                     <div class="section__row section__row--first-small section__row--last-small grid">
-                        <div class="results-total heading heading--four layout__start-one layout__span-two layout__@large-start-two">
+                        <h2 class="results-total heading heading--four layout__start-one layout__span-two layout__@large-start-two">
                             <span class="results-total__anchor" id="results"></span>
                             <span class="results-total__type">Results</span>
                             <span class="results-total__number">{{ result_count }}</span>
-                        </div>
+                        </h2>
                     </div>
                 {% endif %}
 

--- a/rca/project_styleguide/templates/patterns/pages/student/student_index.html
+++ b/rca/project_styleguide/templates/patterns/pages/student/student_index.html
@@ -87,11 +87,11 @@
 
                 {% if results %}
                     <div class="section__row section__row--first-small section__row--last-small grid">
-                        <div class="results-total heading heading--four layout__start-one layout__span-two layout__@large-start-two">
+                        <h2 class="results-total heading heading--four layout__start-one layout__span-two layout__@large-start-two">
                             <span class="results-total__anchor" id="results"></span>
                             <span class="results-total__type">Results</span>
                             <span class="results-total__number">{{ result_count }}</span>
-                        </div>
+                        </h2>
                     </div>
                 {% endif %}
 


### PR DESCRIPTION
Making the results text a heading

Ticket:
https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2207

Staging:
rca-development.herokuapp.com/pattern-library/render-pattern/patterns/pages/events/event_listing.html#
