### PR TITLE
Removing homepage hero scroll option

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/hero/hero--home.html
+++ b/rca/project_styleguide/templates/patterns/molecules/hero/hero--home.html
@@ -1,12 +1,6 @@
 {% load wagtailimages_tags %}
 
 <div class="hero {% if modifier %}hero--{{ modifier }}{% endif %}">
-
-    <div class="hero__scroll">
-        {% include "patterns/atoms/scroll/scroll.html" with link='#content' label='scroll down' %}
-    </div>
-
-
     {% image page.hero_image fill-320x568 as image_small %}
     {% image page.hero_image fill-768x1024 as image_medium %}
     {% image page.hero_image fill-1440x900 as image_large %}

--- a/rca/static_src/sass/components/_hero.scss
+++ b/rca/static_src/sass/components/_hero.scss
@@ -47,21 +47,6 @@
         }
     }
 
-    &__scroll {
-        position: fixed;
-        max-width: $site-width;
-        left: 0;
-        right: ($gutter * 2);
-        margin: 0 auto;
-        bottom: ($gutter * 2);
-        text-align: right;
-
-        @include media-query(medium) {
-            bottom: 50%;
-            right: ($gutter * 3);
-        }
-    }
-
     &__placeholder {
         height: 100vh; /* Fallback for browsers that do not support Custom Properties */
         height: calc(var(--vh, 1vh) * 100);


### PR DESCRIPTION
Removing the scroll functionality due to lack of contrast - this was reported in accessibility reports. Consensus was that it wasn't being used enough to warrent the design time required to ensure it meets accessibility guidelines.

Dev: https://rca-development.herokuapp.com/