### PR TITLE
Styling b tag to use correct font

### DIFF
--- a/rca/static_src/sass/abstracts/_variables.scss
+++ b/rca/static_src/sass/abstracts/_variables.scss
@@ -48,6 +48,7 @@ $font--secondary: 'Benton Sans Medium', 'Helvetica Neue', arial, helvetica,
 
 // Font weights
 // Now handled by font family due to limitations of third party font service
+$weight--bold: 500;
 $weight--medium: 500;
 $weight--normal: 500;
 

--- a/rca/static_src/sass/base/_typography.scss
+++ b/rca/static_src/sass/base/_typography.scss
@@ -49,3 +49,8 @@ small {
 p {
     margin: 0 0 $gutter;
 }
+
+b {
+    font-family: $font--secondary;
+    font-weight: $weight--bold;
+}


### PR DESCRIPTION
RCA uses a different font to style bold items (due to font licensing limitations), this hadn't been applied to the b tag so items within a b looked fuzzy, this MR rectifies this.