### PR TITLE
#2420 page__live isn't a supported QS filter

### DIFF
--- a/rca/editorial/models.py
+++ b/rca/editorial/models.py
@@ -390,14 +390,12 @@ class EditorialListingPage(ContactFieldsMixin, BasePage):
 
     def get_editor_picks(self):
         related_pages = []
-        pages = (
-            self.related_editorial_pages.all()
-            .prefetch_related("page__hero_image", "page__listing_image")
-            .filter(page__live=True)
+        pages = self.related_editorial_pages.all().prefetch_related(
+            "page__hero_image", "page__listing_image"
         )
         for value in pages:
             page = value.page
-            if page:
+            if page and page.live:
                 meta = None
                 school = page.related_schools.first()
                 if school:

--- a/rca/events/models.py
+++ b/rca/events/models.py
@@ -93,14 +93,12 @@ class EventIndexPage(ContactFieldsMixin, BasePage):
 
     def get_editor_picks(self):
         related_pages = []
-        pages = (
-            self.related_event_pages.all()
-            .prefetch_related("page__hero_image", "page__listing_image")
-            .filter(page__live=True)
+        pages = self.related_event_pages.all().prefetch_related(
+            "page__hero_image", "page__listing_image"
         )
         for value in pages:
             page = value.page
-            if page:
+            if page and page.live:
                 meta = page.event_type
                 if page.location:
                     description = f"{page.event_date_short}, {page.location}"


### PR DESCRIPTION
Ticket [2420](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2420)

Resolves sentry error: https://sentry.io/organizations/torchbox/issues/3410762474/?environment=production&project=1542908&query=is%3Aunresolved