### PR TITLE
Add tests for admin UI

### DIFF
--- a/rca/account_management/tests/test_admin.py
+++ b/rca/account_management/tests/test_admin.py
@@ -9,8 +9,12 @@ class TestStudentAdmin(TestCase):
     def setUp(self):
         self.user = UserFactory(is_superuser=True)
         student_group = Group.objects.get(name="Students")
+        editor_group = Group.objects.get(name="Editors")
         self.student_user = UserFactory()
         self.student_user.groups.add(student_group)
+        self.editor = UserFactory()
+        self.editor.groups.add(editor_group)
+
         admin_permission = Permission.objects.get(codename="access_admin")
         student_group.permissions.add(admin_permission)
         self.student_user.save()
@@ -20,6 +24,15 @@ class TestStudentAdmin(TestCase):
         response = self.client.get("/admin/")
         self.assertEqual(response.status_code, 200)
 
+        soup = bs4(response.content, "html.parser")
+        sidebar = soup.find("aside")
+        self.assertIsNotNone(sidebar)
+        self.assertFalse("data-student-sidebar" in sidebar.attrs)
+
+    def test_search_is_visible_for_editors(self):
+        self.client.force_login(self.editor)
+        response = self.client.get("/admin/")
+        self.assertEqual(response.status_code, 200)
         soup = bs4(response.content, "html.parser")
         sidebar = soup.find("aside")
         self.assertIsNotNone(sidebar)

--- a/rca/account_management/tests/test_admin.py
+++ b/rca/account_management/tests/test_admin.py
@@ -8,7 +8,7 @@ from rca.users.factories import UserFactory
 class TestStudentAdmin(TestCase):
     """
     We make some changes to the admin interface if the user is a student.
-    This test is making sure the sitewide search is removed for sutdents,
+    This test is making sure the admin search is removed for sutdents,
     editors and admins should still see the search.
     """
 

--- a/rca/account_management/tests/test_admin.py
+++ b/rca/account_management/tests/test_admin.py
@@ -6,6 +6,12 @@ from rca.users.factories import UserFactory
 
 
 class TestStudentAdmin(TestCase):
+    """
+    We make some changes to the admin interface if the user is a student.
+    This test is making sure the sitewide search is removed for sutdents,
+    editors and admins should still see the search.
+    """
+
     def setUp(self):
         self.user = UserFactory(is_superuser=True)
         student_group = Group.objects.get(name="Students")


### PR DESCRIPTION
Ensure the search bar is still visible for editor roles, not just `admin`