### PR TITLE
#2465 - BE/FE: Programme pages: multiple schools not displaying on front end

### DIFF
--- a/rca/programmes/models.py
+++ b/rca/programmes/models.py
@@ -664,10 +664,8 @@ class ProgrammePage(TapMixin, ContactFieldsMixin, BasePage):
             bits.append(str(self.degree_level))
         return " ".join(bits)
 
-    def get_school(self):
-        related = self.related_schools_and_research_pages.select_related("page").first()
-        if related:
-            return related.page
+    def get_schools(self):
+        return self.related_schools_and_research_pages.select_related("page")
 
     def clean(self):
         super().clean()
@@ -741,8 +739,8 @@ class ProgrammePage(TapMixin, ContactFieldsMixin, BasePage):
         programme_page_global_fields = ProgrammePageGlobalFieldsSettings.for_site(site)
         context["programme_page_global_fields"] = programme_page_global_fields
 
-        # School
-        context["programme_school"] = self.get_school()
+        # Schools
+        context["programme_schools"] = self.get_schools()
         if self.tap_widget:
             context["tap_widget_code"] = mark_safe(self.tap_widget.script_code)
         return context

--- a/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.html
+++ b/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.html
@@ -59,13 +59,15 @@
                 </ul>
             </div>
         {% endif %}
-        {% if programme_school %}
+        {% if programme_schools %}
             <div class="key-details__section key-details__section--school">
                 <h4 class="body body--two key-details__sub-heading">School or Centre</h4>
                 <ul class="key-details__list">
+                    {% for school in programme_schools %}
                     <li class="key-details__list-item">
-                         <a href="{% pageurl programme_school %}" class="link link--tertiary">{{ programme_school.title }}</a>
+                         <a href="{% pageurl school.page %}" class="link link--tertiary">{{ school.page.title }}</a>
                     </li>
+                    {% endfor %}
                 </ul>
             </div>
         {% endif %}

--- a/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.yaml
+++ b/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.yaml
@@ -29,5 +29,13 @@ context:
     key_details_book_or_view_all_open_days_link_title: Book or view all open days
     key_details_application_deadline_title: Application deadline
     key_details_career_opportunities_title: Career opportunities
-  programme_school:
-    title: School of Architecture
+  programme_schools:
+    - page:
+        title: School of Architecture
+    - page:
+        title: School of Design
+
+tags:
+  pageurl:
+    school.page:
+      raw: '#'


### PR DESCRIPTION
Ticket: https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2465

This PR updates the BE and FE to display all related schools/programmes for the programmes pages.

Screenshot:

<img width="1912" alt="Screen Shot 2022-12-05 at 10 43 16 AM" src="https://user-images.githubusercontent.com/13232547/205537919-ad050ef4-3bb3-4eb5-bfa9-9cee5850033e.png">
