### PR TITLE
#2476 Fixes bad rendering of summary values

### DIFF
--- a/rca/events/models.py
+++ b/rca/events/models.py
@@ -602,7 +602,7 @@ class EventDetailPage(ContactFieldsMixin, BasePage):
                     "title": page.listing_title or page.title,
                     "link": page.url,
                     "image": page.listing_image or hero_image,
-                    "description": page.listing_summary or description,
+                    "description": page.listing_summary or strip_tags(description),
                     "meta": meta,
                 }
             )
@@ -715,7 +715,7 @@ class EventDetailPage(ContactFieldsMixin, BasePage):
                     "title": e.title,
                     "link": e.url,
                     "meta": "",  # TODO: on separate ticket
-                    "description": e.introduction,
+                    "description": e.listing_summary or strip_tags(e.introduction),
                     "image": e.listing_image if e.listing_image else e.hero_image,
                 }
                 for e in events

--- a/rca/events/models.py
+++ b/rca/events/models.py
@@ -1,5 +1,6 @@
 import datetime
 import hashlib
+import re
 from urllib.parse import urlencode
 
 from django.core.exceptions import ValidationError
@@ -596,13 +597,14 @@ class EventDetailPage(ContactFieldsMixin, BasePage):
             meta = PAGE_META_MAPPING.get(page.__class__.__name__, "")
             hero_image = getattr(page, "hero_image", None)
             description = getattr(page, "introduction", "")
+            description = re.sub("<a.*?>|</a>", "", description)
 
             related_pages["items"].append(
                 {
                     "title": page.listing_title or page.title,
                     "link": page.url,
                     "image": page.listing_image or hero_image,
-                    "description": page.listing_summary or strip_tags(description),
+                    "description": page.listing_summary or description,
                     "meta": meta,
                 }
             )
@@ -715,7 +717,8 @@ class EventDetailPage(ContactFieldsMixin, BasePage):
                     "title": e.title,
                     "link": e.url,
                     "meta": "",  # TODO: on separate ticket
-                    "description": e.listing_summary or strip_tags(e.introduction),
+                    "description": e.listing_summary
+                    or re.sub("<a.*?>|</a>", "", e.introduction),
                     "image": e.listing_image if e.listing_image else e.hero_image,
                 }
                 for e in events

--- a/rca/guides/models.py
+++ b/rca/guides/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.utils.html import strip_tags
 from django.utils.safestring import mark_safe
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
@@ -106,7 +107,7 @@ class GuidePage(TapMixin, ContactFieldsMixin, BasePage):
                     "title": page.listing_title if page.listing_title else page.title,
                     "image": page.listing_image,
                     "link": page.url,
-                    "description": introduction,
+                    "description": page.listing_summary or strip_tags(introduction),
                 }
             )
         return related_pages

--- a/rca/guides/models.py
+++ b/rca/guides/models.py
@@ -1,5 +1,6 @@
+import re
+
 from django.db import models
-from django.utils.html import strip_tags
 from django.utils.safestring import mark_safe
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
@@ -100,14 +101,14 @@ class GuidePage(TapMixin, ContactFieldsMixin, BasePage):
             if hasattr(page, "programme_description_subtitle"):
                 introduction = page.programme_description_subtitle
             if hasattr(page, "introduction"):
-                introduction = page.introduction
+                introduction = re.sub("<a.*?>|</a>", "", page.introduction)
             related_pages["items"].append(
                 {
                     "page": page,
                     "title": page.listing_title if page.listing_title else page.title,
                     "image": page.listing_image,
                     "link": page.url,
-                    "description": page.listing_summary or strip_tags(introduction),
+                    "description": page.listing_summary or introduction,
                 }
             )
         return related_pages

--- a/rca/project_styleguide/templates/patterns/organisms/index-module/index-module.html
+++ b/rca/project_styleguide/templates/patterns/organisms/index-module/index-module.html
@@ -4,7 +4,7 @@
             <h2 class="index-module__heading heading heading--two {% if anchor_heading %}anchor-heading{% endif %}" {% if anchor_heading %} id="{{ id|slugify }}"{% endif %}>{{ title }}</h2>
         </div>
         <div class="index-module__content">
-            {% if introduction %}<p class="index-module__introduction body body--one">{{ introduction }}</p>{% endif %}
+            {% if introduction %}<p class="index-module__introduction body body--one">{{ introduction|striptags }}</p>{% endif %}
             {% for item in items %}
                 {% include "patterns/molecules/card/card.html" with modifier="simple" card=item %}
             {% endfor %}


### PR DESCRIPTION
This PR makes a few changes to summary and introduction values.
We are only addressing Guides and Evens in this PR, we may want to revisit other areas we choose an introduction or summary to show. It's a bit more work if we start addressing other areas as they are formatted in different ways, so for now we are just addressing what's been raised on the ticket.

Link to test page: http://0.0.0.0:8000/research-innovation/research-centres/helen-hamlyn-centre/include-2022-submissions/

<details>
 <summary>Before: </summary>

![image](https://user-images.githubusercontent.com/2128707/205673679-3f0ee767-b7fc-4a00-908b-b629f7c20084.png)

</details>


<details>
 <summary>After: </summary>

![image](https://user-images.githubusercontent.com/2128707/205673815-e4434932-c2ae-48dd-9c4a-687c7d743111.png)

</details>

