### PR TITLE
#2466 Reorder events to include those in progress

### DIFF
--- a/rca/events/filter.py
+++ b/rca/events/filter.py
@@ -32,7 +32,7 @@ class PastOrFutureFilter:
         if self.selected_value == PastFutureChoices.PAST:
             return queryset.filter(start_date__lt=TODAY)
         if self.selected_value == PastFutureChoices.FUTURE:
-            return queryset.filter(start_date__gte=TODAY).order_by("start_date")
+            return queryset.filter(end_date__gte=TODAY).order_by("end_date")
         # Modify the queryset if no filters are passed in here and show only
         # upcoming dates.
         queryset = queryset.filter(start_date__gte=TODAY).order_by("start_date")

--- a/rca/events/filter.py
+++ b/rca/events/filter.py
@@ -35,7 +35,7 @@ class PastOrFutureFilter:
             return queryset.filter(end_date__gte=TODAY).order_by("end_date")
         # Modify the queryset if no filters are passed in here and show only
         # upcoming dates.
-        queryset = queryset.filter(start_date__gte=TODAY).order_by("start_date")
+        queryset = queryset.filter(end_date__gte=TODAY).order_by("end_date")
         return queryset
 
     @property

--- a/rca/events/filter.py
+++ b/rca/events/filter.py
@@ -32,10 +32,10 @@ class PastOrFutureFilter:
         if self.selected_value == PastFutureChoices.PAST:
             return queryset.filter(start_date__lt=TODAY)
         if self.selected_value == PastFutureChoices.FUTURE:
-            return queryset.filter(end_date__gte=TODAY).order_by("end_date")
+            return queryset.filter(end_date__gte=TODAY).order_by("start_date")
         # Modify the queryset if no filters are passed in here and show only
         # upcoming dates.
-        queryset = queryset.filter(end_date__gte=TODAY).order_by("end_date")
+        queryset = queryset.filter(end_date__gte=TODAY).order_by("start_date")
         return queryset
 
     @property


### PR DESCRIPTION
This PR adjusts the QS for events to include events that are in progress.

Before this, we where filtering for events that start date was greater than or equal to today, what we want is an end_date that is greater than or equal to today; this will include events in the listing that are 1st to 8th of December (if today is the 5th)

Ticket: https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2466

<details>
<summary>Before</summary>

![Screenshot 2022-12-05 at 20-48-04 Events](https://user-images.githubusercontent.com/2128707/205740691-6e6f13c3-fd1e-4e78-b759-f31dc1bc8d81.png)

</details>

<details>
<summary>After</summary>

![Screenshot 2022-12-05 at 20-48-15 Events](https://user-images.githubusercontent.com/2128707/205740727-e2c3d835-306c-4f08-a885-8790f4340b92.png)

</details>