### PR TITLE
#2439 - BE - Listing summary field not being used on news items

### DIFF
--- a/rca/editorial/models.py
+++ b/rca/editorial/models.py
@@ -331,7 +331,7 @@ class EditorialPage(ContactFieldsMixin, BasePage):
                     "title": page.title,
                     "link": page.url,
                     "image": page.listing_image or page.hero_image,
-                    "description": page.introduction or page.listing_summary,
+                    "description": page.listing_summary or page.introduction,
                     "meta": meta,
                 }
             )


### PR DESCRIPTION
Ticket: https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2439

This PR updates the priority in which field to use for the related pages section.

Screenshot (ignore the images):

<img width="1912" alt="Screen Shot 2022-12-06 at 10 51 54 AM" src="https://user-images.githubusercontent.com/13232547/205797361-beadad0b-76ce-44e4-b618-f51c6330d69a.png">