### PR TITLE
#2437 - BE Event items: support events with no end time

### DIFF
--- a/rca/events/models.py
+++ b/rca/events/models.py
@@ -689,8 +689,6 @@ class EventDetailPage(ContactFieldsMixin, BasePage):
             raise ValidationError(
                 {"show_booking_bar": "Please complete all booking fields."}
             )
-        if self.start_time and not self.end_time:
-            raise ValidationError({"end_time": "Please enter an end time."})
         if self.end_time and not self.start_time:
             raise ValidationError({"start_time": "Please enter a start time."})
         if (self.start_time and self.end_time) and (self.start_time >= self.end_time):

--- a/rca/events/models.py
+++ b/rca/events/models.py
@@ -619,6 +619,12 @@ class EventDetailPage(ContactFieldsMixin, BasePage):
         TIME_FORMAT = "fA"
         if self.start_time:
             start_time = time(self.start_time, TIME_FORMAT).lower()
+
+            # End time is optional so formatting is different if the
+            # event does not have an end time.
+            if not self.end_time:
+                return start_time
+
             end_time = time(self.end_time, TIME_FORMAT).lower()
             return f"{start_time} \u2013 {end_time}"
         return ""

--- a/rca/events/tests/test_models.py
+++ b/rca/events/tests/test_models.py
@@ -263,32 +263,25 @@ class EventDetailPageDateTests(WagtailPageTests):
                 )
 
     def test_event_time_required(self):
-        testcases = (
-            (time(9), None, "Please enter an end time."),
-            (None, time(12, 59), "Please enter a start time."),
-        )
-        for start_time, end_time, message in testcases:
-            with self.subTest(
-                f"Testing time required: start time: {start_time}, end time: {end_time}",
+        start_time = None
+        end_time = time(12, 59)
+        message = "Please enter a start time."
+
+        with self.assertRaises(ValidationError) as cm:
+            EventDetailPageFactory.build(
                 start_time=start_time,
                 end_time=end_time,
-                message=message,
-            ):
-                with self.assertRaises(ValidationError) as cm:
-                    EventDetailPageFactory.build(
-                        start_time=start_time,
-                        end_time=end_time,
-                        path="0",
-                        depth=0,
-                        event_type=EventTypeFactory(),
-                        location=EventLocationFactory(),
-                        eligibility=EventEligibilityFactory(),
-                    ).full_clean()
+                path="0",
+                depth=0,
+                event_type=EventTypeFactory(),
+                location=EventLocationFactory(),
+                eligibility=EventEligibilityFactory(),
+            ).full_clean()
 
-                the_exception = cm.exception
+        the_exception = cm.exception
 
-                self.assertEqual(1, len(the_exception.messages))
-                self.assertEqual(message, the_exception.messages[0])
+        self.assertEqual(1, len(the_exception.messages))
+        self.assertEqual(message, the_exception.messages[0])
 
 
 class EventDetailPageRelatedContentTests(WagtailPageTests):


### PR DESCRIPTION
Ticket: https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2437

This PR removes the validation for the `end_time` when creating or editing an event detail page. I've confirmed that removing the validation won't break importing the page to the intranet.

Screenshot:

Left is the one from RCA website and right is the one from the intranet after running the import.

<img width="1800" alt="Import" src="https://user-images.githubusercontent.com/13232547/206067457-6996d2ac-c1ba-4ac6-8fc3-b456bc59c011.png">
