### PR TITLE
Install poetry using pip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ jobs:
       - run:
           name: install python dependencies
           command: |
-            curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_VERSION=1.1.8 python
-            . $HOME/.poetry/env
+            pip install --upgrade pip
+            pip install poetry==1.1.15
             python -m venv venv
             . ./venv/bin/activate
             poetry install


### PR DESCRIPTION
The CI command that uses this url:

`curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py ...`

is no longer available and returns 404.

This updates the installation of poetry to use pip.