### PR TITLE
#2489 - SPIKE News index jumps when scrolling through Editorial picks carousel

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/people-carousel/people-carousel.html
+++ b/rca/project_styleguide/templates/patterns/molecules/people-carousel/people-carousel.html
@@ -20,12 +20,12 @@
     </div>
 
     <div class="carousel__controls-group grid" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
-        <button class="carousel__button carousel__button--prev button" aria-label="Previous slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
+        <button class="carousel__button carousel__button--prev button" type="button" aria-label="Previous slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
             <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
                 <use xlink:href="#arrow-left" />
             </svg>
         </button>
-        <button class="carousel__button carousel__button--next button" aria-label="Next slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
+        <button class="carousel__button carousel__button--next button" type="button" aria-label="Next slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
             <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
                 <use xlink:href="#arrow-right" />
             </svg>

--- a/rca/project_styleguide/templates/patterns/organisms/carousel/carousel--quotes.html
+++ b/rca/project_styleguide/templates/patterns/organisms/carousel/carousel--quotes.html
@@ -10,12 +10,12 @@
             {% endfor %}
         </ul>
         <div class="carousel__controls-group grid" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
-            <button class="carousel__button carousel__button--prev button" aria-label="Previous quote{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
+            <button class="carousel__button carousel__button--prev button" type="button" aria-label="Previous quote{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
                     <use xlink:href="#arrow-left" />
                 </svg>
             </button>
-            <button class="carousel__button carousel__button--next button" aria-label="Next quote{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
+            <button class="carousel__button carousel__button--next button" type="button" aria-label="Next quote{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
                     <use xlink:href="#arrow-right" />
                 </svg>

--- a/rca/project_styleguide/templates/patterns/organisms/carousel/carousel--square.html
+++ b/rca/project_styleguide/templates/patterns/organisms/carousel/carousel--square.html
@@ -10,12 +10,12 @@
             {% endfor %}
         </ul>
         <div class="carousel__controls-group grid" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
-            <button class="carousel__button carousel__button--prev button" aria-label="Previous slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
+            <button class="carousel__button carousel__button--prev button" type="button" aria-label="Previous slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
                     <use xlink:href="#arrow-left" />
                 </svg>
             </button>
-            <button class="carousel__button carousel__button--next button" aria-label="Next slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
+            <button class="carousel__button carousel__button--next button" type="button" aria-label="Next slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
                     <use xlink:href="#arrow-right" />
                 </svg>

--- a/rca/project_styleguide/templates/patterns/organisms/carousel/carousel.html
+++ b/rca/project_styleguide/templates/patterns/organisms/carousel/carousel.html
@@ -18,12 +18,12 @@
             {% endfor %}
         </div>
         <div class="carousel__controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
-            <button class="carousel__button carousel__button--prev button" aria-label="Previous slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
+            <button class="carousel__button carousel__button--prev button" type="button" aria-label="Previous slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
                     <use xlink:href="#arrow-left" />
                 </svg>
             </button>
-            <button class="carousel__button carousel__button--next button" aria-label="Next slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
+            <button class="carousel__button carousel__button--next button" type="button" aria-label="Next slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
                     <use xlink:href="#arrow-right" />
                 </svg>

--- a/rca/project_styleguide/templates/patterns/organisms/carousel/carousel_api_content.html
+++ b/rca/project_styleguide/templates/patterns/organisms/carousel/carousel_api_content.html
@@ -15,12 +15,12 @@
             {% endfor %}
         </div>
         <div class="carousel__controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
-            <button class="carousel__button carousel__button--prev button" aria-label="Previous slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
+            <button class="carousel__button carousel__button--prev button" type="button" aria-label="Previous slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
                     <use xlink:href="#arrow-left" />
                 </svg>
             </button>
-            <button class="carousel__button carousel__button--next button" aria-label="Next slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
+            <button class="carousel__button carousel__button--next button" type="button" aria-label="Next slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
                     <use xlink:href="#arrow-right" />
                 </svg>

--- a/rca/project_styleguide/templates/patterns/organisms/logo-carousel/logo-carousel.html
+++ b/rca/project_styleguide/templates/patterns/organisms/logo-carousel/logo-carousel.html
@@ -17,12 +17,12 @@
         </ul>
     </div>
     <div class="carousel__controls-group grid" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
-        <button class="carousel__button carousel__button--prev button" aria-label="Previous slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
+        <button class="carousel__button carousel__button--prev button" type="button" aria-label="Previous slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
             <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
                 <use xlink:href="#arrow-left" />
             </svg>
         </button>
-        <button class="carousel__button carousel__button--next button" aria-label="Next slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
+        <button class="carousel__button carousel__button--next button" type="button" aria-label="Next slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
             <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
                 <use xlink:href="#arrow-right" />
             </svg>


### PR DESCRIPTION
Ticket: https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2489

Issue: The carousel is displayed inside a form (for filtering). When a user clicks on a carousel arrow, the form shouldn't be submitted.