### PR TITLE
Alllow passing button title to news_api_content template

### DIFF
--- a/rca/project_styleguide/templates/patterns/organisms/news/news_api_content.html
+++ b/rca/project_styleguide/templates/patterns/organisms/news/news_api_content.html
@@ -17,7 +17,7 @@
 
         {% if forloop.last and not forloop.first %}
                 <a class="news__view-all link link--primary link--link body body--two" href="{{ page.news_view_all.link|default:'/news-and-events/' }}">
-                    <span class="link__label">{{ page.news_view_all.title|default:'See all news & events' }}</span>
+                    <span class="link__label">{% firstof button_title page.news_view_all.title 'See all news & events' %}</span>
                     <svg class="link__icon" width="12" height="8"><use xlink:href="#arrow"></use></svg>
                 </a>
             </div>

--- a/rca/project_styleguide/templates/patterns/organisms/news/news_api_content.html
+++ b/rca/project_styleguide/templates/patterns/organisms/news/news_api_content.html
@@ -16,7 +16,7 @@
         {% endif %}
 
         {% if forloop.last and not forloop.first %}
-                <a class="news__view-all link link--primary link--link body body--two" href="{{ page.news_view_all.link|default:'/news-and-events/' }}">
+                <a class="news__view-all link link--primary link--link body body--two" href="{% firstof button_link page.news_view_all.link '/news-and-events/' %}">
                     <span class="link__label">{% firstof button_title page.news_view_all.title 'See all news & events' %}</span>
                     <svg class="link__icon" width="12" height="8"><use xlink:href="#arrow"></use></svg>
                 </a>

--- a/rca/project_styleguide/templates/patterns/pages/editorial_event_landing/editorial_event_landing.html
+++ b/rca/project_styleguide/templates/patterns/pages/editorial_event_landing/editorial_event_landing.html
@@ -41,7 +41,7 @@
                         <h2 class="section__heading section__heading--primary heading heading--two">Events</h2>
                     </div>
                     <div class="section__content grid">
-                        {% include "patterns/organisms/news/news_api_content.html" with news=events news_view_all=page.events_view_all modifier="news--single-feature" %}
+                        {% include "patterns/organisms/news/news_api_content.html" with news=events news_view_all=page.events_view_all modifier="news--single-feature" button_title=page.events_link_text %}
                     </div>
                 </div>
             </section>

--- a/rca/project_styleguide/templates/patterns/pages/editorial_event_landing/editorial_event_landing.html
+++ b/rca/project_styleguide/templates/patterns/pages/editorial_event_landing/editorial_event_landing.html
@@ -41,7 +41,7 @@
                         <h2 class="section__heading section__heading--primary heading heading--two">Events</h2>
                     </div>
                     <div class="section__content grid">
-                        {% include "patterns/organisms/news/news_api_content.html" with news=events news_view_all=page.events_view_all modifier="news--single-feature" button_title=page.events_link_text %}
+                        {% include "patterns/organisms/news/news_api_content.html" with news=events news_view_all=page.events_view_all modifier="news--single-feature" button_title=page.events_link_text button_link=page.events_link_target_url %}
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
Ticket: [here](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2494)

Hi, 

this is a simple fix to passthrough the correct button title from the EELandingPage model, it was passing througt the news button title instead of the event. I've just made it a little more flexible to allow for this.

Image of fixed page: 
![image](https://user-images.githubusercontent.com/22497837/227499086-2bec5a63-d8d2-40d2-8edd-051cb573fc08.png)


Thanks - Will. 