### PR TITLE
#2505 | Fix: Conditional rendering of images on Requirements and Apply tab optional

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/image-caption-link/image-caption-link.html
+++ b/rca/project_styleguide/templates/patterns/molecules/image-caption-link/image-caption-link.html
@@ -8,11 +8,12 @@
     {% else %}
         <div class="image-caption-link__container">
     {% endif %}
+        {% if image %}
+            {% image image fill-80x37 as image_small %}
+            {% image image fill-900x415 as image_large %}
 
-        {% image image fill-80x37 as image_small %}
-        {% image image fill-900x415 as image_large %}
-
-        {% include "patterns/atoms/image/image--lazyload.html" with image_small=image_small width=900 height=415 image_large=image_large classList='image-caption-link__image' %}
+            {% include "patterns/atoms/image/image--lazyload.html" with image_small=image_small width=900 height=415 image_large=image_large classList='image-caption-link__image' %}
+        {% endif %}
         {% if modal %}
             <svg width="24" height="24" class="image-caption-link__image-icon" aria-hidden="true"><use xlink:href="#play-icon"></use></svg>
 

--- a/rca/project_styleguide/templates/patterns/organisms/image-video-block/image-video-block.html
+++ b/rca/project_styleguide/templates/patterns/organisms/image-video-block/image-video-block.html
@@ -16,7 +16,9 @@
     {% if not out_of_grid %}
         <div class="section__row grid">
     {% endif %}
-        {% include "patterns/molecules/image-caption-link/image-caption-link.html" with caption=caption modal=modal %}
+        {% if image or video %}
+            {% include "patterns/molecules/image-caption-link/image-caption-link.html" with caption=caption modal=modal %}
+        {% endif %}
     {% if not out_of_grid %}
         </div>
     {% endif %}

--- a/rca/project_styleguide/templates/patterns/organisms/programme_tabs/apply.html
+++ b/rca/project_styleguide/templates/patterns/organisms/programme_tabs/apply.html
@@ -4,9 +4,11 @@
     </header>
     <div class="section__content">
 
-        <div class="section__row grid">
-            {% include "patterns/atoms/image/image--right.html" with image=page.apply_image modifier='image--right' %}
-        </div>
+        {% if page.apply_image %}
+            <div class="section__row grid">
+                {% include "patterns/atoms/image/image--right.html" with image=page.apply_image modifier='image--right' %}
+            </div>
+        {% endif %}
 
         <div class="section__row">
             {% include "patterns/molecules/apply-intro/apply-intro.html" %}


### PR DESCRIPTION
[Ticket](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2505)

When a _curriculum image_ or _apply image_ is not specified on a Programme page, we expect that the image should not be rendered at all. However, what happens is that the image block is displayed with a null URL. This PR fixes this by checking that the images exist before proceeding to render them.

<details>
  <summary>Here is an illustration</summary>

https://github.com/torchbox/rca-wagtail-2019/assets/7713776/feaccdcb-ffb0-4986-b0f6-55aa95af9a54

</details>
