### PR TITLE
pre-commit - fix URL for isort hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     rev: v4.3.18
     hooks:
       - id: isort
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     # flake8 config is in setup.cfg
     rev: 3.8.3
     hooks:


### PR DESCRIPTION
This updates the isort pre-commit hook URL from gitlab to github, as the former no longer works, breaking the pre-commit functionality altogether.