### PR TITLE
#2509 BE Programme finder > Add study mode filter

### DIFF
--- a/rca/programmes/models.py
+++ b/rca/programmes/models.py
@@ -246,6 +246,8 @@ class ProgrammeStudyModeProgrammePage(models.Model):
     )
     panels = [FieldPanel("programme_study_mode")]
 
+    api_fields = [APIField("programme_study_mode")]
+
     def __str__(self):
         return self.programme_study_mode.title
 
@@ -775,6 +777,8 @@ class ProgrammePage(TapMixin, ContactFieldsMixin, BasePage):
             name="hero_image_square",
             serializer=ImageRenditionField("fill-580x580", source="hero_image"),
         ),
+        # Additional field(s) for filtering, specific to programmes.
+        APIField("programme_study_modes"),
         # Displayed fields, specific to programmes.
         APIField("degree_level", serializer=degree_level_serializer()),
         APIField("pathway_blocks"),
@@ -971,6 +975,16 @@ class ProgrammeIndexPage(ContactFieldsMixin, BasePage):
             for i in Subject.objects.all().order_by("title")
         ]
 
+        programme_study_modes = [
+            {
+                "title": i.title,
+                "id": i.id,
+                "description": "",
+                "slug": i.slug,
+            }
+            for i in ProgrammeStudyMode.objects.all()
+        ]
+
         schools_and_research_pages = []
 
         schools_and_research_pages_queryset = chain(
@@ -996,6 +1010,11 @@ class ProgrammeIndexPage(ContactFieldsMixin, BasePage):
                 "id": "related_schools_and_research_pages",
                 "title": "Schools & centres",
                 "items": schools_and_research_pages,
+            },
+            {
+                "id": "programme_study_modes",
+                "title": "Study mode",
+                "items": programme_study_modes,
             },
         ]
 

--- a/rca/programmes/models.py
+++ b/rca/programmes/models.py
@@ -752,6 +752,10 @@ class ProgrammePage(TapMixin, ContactFieldsMixin, BasePage):
             [index.RelatedFields("subject", [index.SearchField("title")])],
         ),
         index.RelatedFields(
+            "programme_study_modes",
+            [index.RelatedFields("programme_study_mode", [index.SearchField("title")])],
+        ),
+        index.RelatedFields(
             "tagged_programme_items",
             [
                 index.RelatedFields(
@@ -975,16 +979,6 @@ class ProgrammeIndexPage(ContactFieldsMixin, BasePage):
             for i in Subject.objects.all().order_by("title")
         ]
 
-        programme_study_modes = [
-            {
-                "title": i.title,
-                "id": i.id,
-                "description": "",
-                "slug": i.slug,
-            }
-            for i in ProgrammeStudyMode.objects.all()
-        ]
-
         schools_and_research_pages = []
 
         schools_and_research_pages_queryset = chain(
@@ -1010,11 +1004,6 @@ class ProgrammeIndexPage(ContactFieldsMixin, BasePage):
                 "id": "related_schools_and_research_pages",
                 "title": "Schools & centres",
                 "items": schools_and_research_pages,
-            },
-            {
-                "id": "programme_study_modes",
-                "title": "Study mode",
-                "items": programme_study_modes,
             },
         ]
 

--- a/rca/shortcourses/models.py
+++ b/rca/shortcourses/models.py
@@ -342,19 +342,6 @@ class ShortCoursePage(ContactFieldsMixin, BasePage):
     ]
 
     @property
-    def programme_study_modes(self):
-        """
-        This is used by the StudyModeFilter filter in the Wagtail API.
-        See rca/wagtailapi/filters.py.
-
-        It's here because don't have a programme_study_mode field
-        on this model, but we want to always include short courses
-        regardless of the study mode filter option.
-        """
-
-        pass
-
-    @property
     def listing_meta(self):
         # Returns a page 'type' value that's readable for listings,
         return "Short course"

--- a/rca/shortcourses/models.py
+++ b/rca/shortcourses/models.py
@@ -22,7 +22,6 @@ from wagtail.core.models import Orderable
 from wagtail.images import get_image_model_string
 from wagtail.images.api.fields import ImageRenditionField
 from wagtail.search import index
-from wagtail.snippets.edit_handlers import SnippetChooserPanel
 
 from rca.programmes.models import ProgrammeType
 from rca.utils.blocks import (
@@ -341,6 +340,19 @@ class ShortCoursePage(ContactFieldsMixin, BasePage):
             serializer=ImageRenditionField("fill-580x580", source="hero_image"),
         ),
     ]
+
+    @property
+    def programme_study_modes(self):
+        """
+        This is used by the StudyModeFilter filter in the Wagtail API.
+        See rca/wagtailapi/filters.py.
+
+        It's here because don't have a programme_study_mode field
+        on this model, but we want to always include short courses
+        regardless of the study mode filter option.
+        """
+
+        pass
 
     @property
     def listing_meta(self):

--- a/rca/static_src/javascript/components/programme-toggle-switch.js
+++ b/rca/static_src/javascript/components/programme-toggle-switch.js
@@ -24,7 +24,7 @@ class ProgrammeToggleSwitch {
             this.checkbox.checked = true;
         }
 
-        if (this.isPartTime === 'false' || !this.isPartTime) {
+        if (this.isPartTime === false || !this.isPartTime) {
             this.checkbox.checked = false;
         }
     }

--- a/rca/static_src/javascript/components/programme-toggle-switch.js
+++ b/rca/static_src/javascript/components/programme-toggle-switch.js
@@ -1,0 +1,63 @@
+class ProgrammeToggleSwitch {
+    static selector() {
+        return '[data-study-mode-toggle]';
+    }
+
+    constructor(button) {
+        this.toggleSwitch = button;
+        this.checkbox = this.toggleSwitch.firstElementChild;
+
+        const location_root = window.location.href;
+
+        this.programmes_path = window.location.pathname;
+
+        const paramString = location_root.split('?')[1];
+        this.queryString = new URLSearchParams(paramString);
+        this.isPartTime = this.queryString.get('part-time');
+
+        this.buttonStatus();
+        this.bindEvents();
+    }
+
+    buttonStatus() {
+        if (this.isPartTime === 'true') {
+            this.checkbox.checked = true;
+        }
+
+        if (this.isPartTime === 'false' || !this.isPartTime) {
+            this.checkbox.checked = false;
+        }
+    }
+
+    applyToggle() {
+        if (!this.isPartTime) {
+            this.queryString.set('part-time', 'true');
+            const url = `${
+                this.programmes_path
+            }?${this.queryString.toString()}`;
+            window.location = url;
+        }
+
+        if (this.isPartTime === 'true') {
+            this.queryString.set('part-time', 'false');
+            const url = `${
+                this.programmes_path
+            }?${this.queryString.toString()}`;
+            window.location = url;
+        }
+
+        if (this.isPartTime === 'false') {
+            this.queryString.set('part-time', 'true');
+            const url = `${
+                this.programmes_path
+            }?${this.queryString.toString()}`;
+            window.location = url;
+        }
+    }
+
+    bindEvents() {
+        this.toggleSwitch.addEventListener('click', () => this.applyToggle());
+    }
+}
+
+export default ProgrammeToggleSwitch;

--- a/rca/static_src/javascript/main.entry.js
+++ b/rca/static_src/javascript/main.entry.js
@@ -1,37 +1,38 @@
 import '@babel/polyfill';
 import Alpine from 'alpinejs';
 
+import Accordion from './components/accordion';
+import ActualHeight from './components/actual-height';
+import AnchorNav from './components/anchor-nav';
+import BackLink from './components/back-link';
+import Carousel from './components/carousel';
+import PeekFullCarousel from './components/carousel-full-peek';
+import PeekCarousel from './components/carousel-peek';
+import CookieWarning from './components/cookie-message';
+import EmailShare from './components/email-share';
+import EventToggleSwitch from './components/event-toggle-switch';
+import FormFocus from './components/form-focus';
 import GridSizeVariables from './components/grid-size-variables';
 import HeaderDrawer from './components/header-drawer';
-import SubMenu from './components/submenu';
-import BackLink from './components/back-link';
-import MobileSubMenu from './components/mobile-sub-menu';
-import CookieWarning from './components/cookie-message';
-import Accordion from './components/accordion';
-import Tabs from './components/tabs';
-import Carousel from './components/carousel';
-import PeekCarousel from './components/carousel-peek';
-import PeekFullCarousel from './components/carousel-full-peek';
-import Slideshow from './components/slideshow';
-import VideoModal from './components/video-modal';
-import RelatedContent from './components/related-content';
-import Sticky from './components/position-sticky-event';
-import ActualHeight from './components/actual-height';
-import ProjectFilters from './components/project-filters';
-import AnchorNav from './components/anchor-nav';
-import SitewideAlert from './components/sitewide-alert';
-import FormFocus from './components/form-focus';
-import EmailShare from './components/email-share';
-import ScholarshipList from './components/scholarship-list';
-import EventToggleSwitch from './components/event-toggle-switch';
-import './components/sticky-header';
-import './components/lazyload-images';
-import './components/outdated-banner';
 import './components/home-menu';
-import './components/stats-block';
-import './components/parallax';
+import './components/lazyload-images';
+import MobileSubMenu from './components/mobile-sub-menu';
 import './components/modal';
+import './components/outdated-banner';
+import './components/parallax';
+import Sticky from './components/position-sticky-event';
+import ProgrammeToggleSwitch from './components/programme-toggle-switch';
+import ProjectFilters from './components/project-filters';
+import RelatedContent from './components/related-content';
+import ScholarshipList from './components/scholarship-list';
+import SitewideAlert from './components/sitewide-alert';
+import Slideshow from './components/slideshow';
+import './components/stats-block';
+import './components/sticky-header';
 import './components/sticky-point';
+import SubMenu from './components/submenu';
+import Tabs from './components/tabs';
+import VideoModal from './components/video-modal';
 
 import '../sass/main.scss';
 
@@ -151,6 +152,12 @@ document.addEventListener('DOMContentLoaded', () => {
         EventToggleSwitch.selector(),
     )) {
         new EventToggleSwitch(eventtoggleswitch);
+    }
+
+    for (const studymodetoggleswitch of document.querySelectorAll(
+        ProgrammeToggleSwitch.selector(),
+    )) {
+        new ProgrammeToggleSwitch(studymodetoggleswitch);
     }
 
     new ActualHeight();

--- a/rca/static_src/javascript/programmes/components/ProgrammesExplorer.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesExplorer.js
@@ -1,13 +1,14 @@
-import React from 'react';
 import PropTypes from 'prop-types';
-import { useLocation } from 'react-use';
+import React from 'react';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
+import { useLocation } from 'react-use';
 
 import { programmeCategories } from '../programmes.types';
 
-import SearchForm from './SearchForm';
-import ProgrammesResults from './ProgrammesResults/ProgrammesResults';
 import ProgrammesCategories from './ProgrammesCategories/ProgrammesCategories';
+import ProgrammesResults from './ProgrammesResults/ProgrammesResults';
+import SearchForm from './SearchForm';
+import ToggleSwitch from './StudyModeToggleSwitch';
 
 /**
  * Programmes and short courses listing, with a search form, filters, and a results view.
@@ -28,6 +29,12 @@ const ProgrammesExplorer = ({ searchLabel, categories }) => {
     return (
         <>
             <SearchForm searchQuery={searchQuery} label={searchLabel} />
+            {/* Study mode toggler placeholder */}
+            <ToggleSwitch
+                ariaLabel="Programme study mode"
+                labelOne="Full-time"
+                labelTwo="Part-time"
+            />
             <TransitionGroup className="explorer-transitions">
                 {showCategories ? (
                     <CSSTransition

--- a/rca/static_src/javascript/programmes/components/StudyModeToggleSwitch.js
+++ b/rca/static_src/javascript/programmes/components/StudyModeToggleSwitch.js
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const ToggleSwitch = ({ ariaLabel, labelOne, labelTwo }) => {
+    return (
+        // eslint-disable-next-line jsx-a11y/label-has-associated-control
+        <label
+            className="toggle-switch"
+            data-study-mode-toggle
+            aria-label={ariaLabel}
+        >
+            <input type="checkbox" className="toggle-switch__checkbox" />
+            <span className="toggle-switch__switch" />
+            <span className="toggle-switch__label toggle-switch__label--first">
+                {labelOne}
+            </span>
+            <span className="toggle-switch__label toggle-switch__label--last">
+                {labelTwo}
+            </span>
+        </label>
+    );
+};
+
+ToggleSwitch.propTypes = {
+    ariaLabel: PropTypes.string.isRequired,
+    labelOne: PropTypes.string.isRequired,
+    labelTwo: PropTypes.string.isRequired,
+};
+
+export default ToggleSwitch;

--- a/rca/static_src/javascript/programmes/programmes.api.js
+++ b/rca/static_src/javascript/programmes/programmes.api.js
@@ -37,12 +37,14 @@ export const getWagtailAPIQueryString = ({
     type,
     fields,
     limit,
+    partTime,
 }) => {
     const parameters = {
-        type: type || null,
-        limit: limit || null,
-        fields: fields.join(',') || null,
-        search: search || null,
+        'type': type || null,
+        'part-time': partTime !== undefined ? partTime : 'false',
+        'limit': limit || null,
+        'fields': fields.join(',') || null,
+        'search': search || null,
         ...filters,
     };
     Object.keys(parameters).forEach((param) => {
@@ -64,6 +66,11 @@ let abortGetProgrammes = new AbortController();
  * Or both!
  */
 export const getProgrammes = ({ query, filters = {} }) => {
+    // Check the window for a part-time query param and apply that.
+    const urlParams = new URLSearchParams(window.location.search);
+    const partTimeParam = urlParams.get('part-time');
+    const partTime = partTimeParam === 'true';
+
     // Abort the previous controller if any, and create a new one.
     abortGetProgrammes.abort();
     abortGetProgrammes = new AbortController();
@@ -71,6 +78,7 @@ export const getProgrammes = ({ query, filters = {} }) => {
     const requests = listedPageTypes.map(({ type, fields }) => {
         const queryString = getWagtailAPIQueryString({
             search: query,
+            partTime, // Pass the partTime value to the query string generator.
             filters,
             type,
             fields,

--- a/rca/static_src/javascript/programmes/programmes.api.test.js
+++ b/rca/static_src/javascript/programmes/programmes.api.test.js
@@ -7,10 +7,11 @@ describe('getWagtailAPIQueryString', () => {
         type: '',
         fields: [],
         limit: null,
+        partTime: undefined,
     };
 
     it('empty', () => {
-        expect(getWagtailAPIQueryString(empty)).toBe('');
+        expect(getWagtailAPIQueryString(empty)).toBe('?part-time=false');
     });
 
     it('all options', () => {
@@ -21,9 +22,10 @@ describe('getWagtailAPIQueryString', () => {
                 search: 'test',
                 fields: ['test', 'title'],
                 filters: { promoted: true, price: 15 },
+                partTime: 'true',
             }),
         ).toBe(
-            '?type=core.TestPage&limit=50&fields=test%2Ctitle&search=test&promoted=true&price=15',
+            '?type=core.TestPage&part-time=true&limit=50&fields=test%2Ctitle&search=test&promoted=true&price=15',
         );
     });
 });

--- a/rca/wagtailapi/views.py
+++ b/rca/wagtailapi/views.py
@@ -10,7 +10,6 @@ from .serializers import RCAImageSerializer, RCAPageSerializer
 
 
 class PagesAPIViewSet(views.PagesAPIViewSet):
-
     base_serializer_class = RCAPageSerializer
 
     filter_backends = [
@@ -21,8 +20,15 @@ class PagesAPIViewSet(views.PagesAPIViewSet):
         DescendantOfFilter,
         filters.RelatedSchoolsFilter,
         filters.SubjectsFilter,
+        filters.StudyModeFilter,
         filters.SearchFilter,
     ]
+
+    known_query_parameters = views.PagesAPIViewSet.known_query_parameters.union(
+        [
+            "programme_study_modes",
+        ]
+    )
 
     meta_fields = views.PagesAPIViewSet.meta_fields + [
         "children",

--- a/rca/wagtailapi/views.py
+++ b/rca/wagtailapi/views.py
@@ -26,7 +26,7 @@ class PagesAPIViewSet(views.PagesAPIViewSet):
 
     known_query_parameters = views.PagesAPIViewSet.known_query_parameters.union(
         [
-            "programme_study_modes",
+            "part-time",
         ]
     )
 


### PR DESCRIPTION
[Ticket](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2509)

This is to allow users to filter programmes by study mode.

Changes made:

- added a new BaseFilterBackend which checks for 'part-time'  in the API GET query params, then filters the queryset accordingly (d6edbb73)
- added a `StudyModeToggleSwitch` React component (8920b594)
- added logic to handle events on the toggle switch  (b7aa3f49)
- updated the frontend API logic to include filtering results by part-time (0f636413)

<details>
  <summary>Illustration</summary>

https://github.com/torchbox/rca-wagtail-2019/assets/7713776/d0cc5936-a196-4fb1-8a5e-af8758804537

</details>


>**Warning**
>
> - ~~The JS test suite is broken, needs fixing, @nicklee would you please take a look?~~ fixed in b539acdc
> - The toggle component state needs fixing