### PR TITLE
#2504 » Programme page > Key details > Enable Open Day link to show up without Open Day date

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.html
+++ b/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.html
@@ -71,19 +71,23 @@
                 </ul>
             </div>
         {% endif %}
-        {% if page.next_open_day_date %}
+        {% if page.next_open_day_date or page.link_to_open_days %}
             <div class="key-details__section key-details__section--open-days">
                 {% if programme_page_global_fields.key_details_next_open_day_title %}
                     <h4 class="body body--two key-details__sub-heading">{{ programme_page_global_fields.key_details_next_open_day_title }}</h4>
                 {% endif %}
                 <ul class="key-details__list">
-                    <li class="key-details__list-item">{{ page.next_open_day_date }}</li>
-                    <li class="key-details__list-item">
-                        <a class="key-details__link link link--secondary link--link" href="{{ page.link_to_open_days }}">
-                            <span class="link__label">{{ programme_page_global_fields.key_details_book_or_view_all_open_days_link_title }}</span>
-                            <svg width="12" height="8" class="link__icon" aria-hidden="true"><use xlink:href="#arrow"></use></svg>
-                        </a>
-                    </li>
+                    {% if page.next_open_day_date %}
+                        <li class="key-details__list-item">{{ page.next_open_day_date }}</li>
+                    {% endif %}
+                    {% if page.link_to_open_days %}
+                        <li class="key-details__list-item">
+                            <a class="key-details__link link link--secondary link--link" href="{{ page.link_to_open_days }}">
+                                <span class="link__label">{{ programme_page_global_fields.key_details_book_or_view_all_open_days_link_title }}</span>
+                                <svg width="12" height="8" class="link__icon" aria-hidden="true"><use xlink:href="#arrow"></use></svg>
+                            </a>
+                        </li>
+                    {% endif %}
                 </ul>
             </div>
         {% endif %}


### PR DESCRIPTION
[Ticket](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2504)

This PR modifies the display of programme page key details so that the link to open days is rendered even when next open day date is not specified.

<details>
  <summary>Before</summary>

![Screenshot from 2023-08-18 08-03-29](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/81a4cd1a-8ec4-4337-ae3a-3acdde033072)

</details>

<details>
  <summary>After</summary>

![Screenshot from 2023-08-18 08-04-28](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/2fae7000-08a8-45b7-a5d6-87b64952ec45)

</details>
