### PR TITLE
#2518 » School page > Key details > Enable Open Day link to show up without Open Day date

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/key-details/key-details--schools.html
+++ b/rca/project_styleguide/templates/patterns/molecules/key-details/key-details--schools.html
@@ -28,11 +28,13 @@
     </div>
     {% endif %}
 
-    {% if page.next_open_day_date %}
+    {% if page.next_open_day_date or page.link_to_open_days %}
     <div class="key-details__section key-details__section--date">
         <h3 class="body body--two key-details__sub-heading">Next open day</h3>
         <ul class="key-details__list" >
-            <li class="key-details__list-item">{{ page.next_open_day_date|date:'j M Y' }}</li>
+            {% if page.next_open_day_date %}
+                <li class="key-details__list-item">{{ page.next_open_day_date|date:'j M Y' }}</li>
+            {% endif %}
             {% if page.link_to_open_days %}
             <li class="key-details__list-item">
                 <a class="key-details__link link link--secondary link--link" href="{{ page.link_to_open_days }}">


### PR DESCRIPTION
[Ticket](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2518)

This PR modifies the display of school page key details so that the link to open days is rendered even when next open day date is not specified.

>**Note**
>
> This is similar to #951, which does the same thing but on programme pages. 

<details>
  <summary>Before</summary>

![image](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/a3e7756c-5399-490f-b80b-bdbe258575ef)

</details>

<details>
  <summary>After</summary>

![image](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/05393e78-d45b-4b6a-ba8e-f43bdf0fca35)

</details>
