### PR TITLE
#2516 » Guide page > 'On this page' side menu > change heading

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/anchor-nav/anchor-nav.html
+++ b/rca/project_styleguide/templates/patterns/molecules/anchor-nav/anchor-nav.html
@@ -1,5 +1,10 @@
   <div class="anchor-nav" data-anchor-nav>
-    <h2 class="anchor-nav__heading">On this page</h2>
+    <h2 class="anchor-nav__heading">
+        Jump to
+        <svg width="12" height="8" class="jump-nav__heading-icon" aria-hidden="true">
+            <use xlink:href="#arrow"></use>
+        </svg>
+    </h2>
     <nav class="anchor-nav__nav-container">
       <ul class="anchor-nav__items">
         {% for item in anchor_nav %}


### PR DESCRIPTION
[Ticket](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2516)

This PR changes the `anchor-nav` heading text to match that of the `jump-nav`.

<details>
  <summary>Before</summary>

![image](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/20733fb2-8a47-4d47-8622-3e30a3650620)

![image](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/9474af77-3173-4b1a-9c96-b631caa3bf6d)

</details>

<details>
  <summary>After</summary>

![image](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/4088425b-efcb-484b-a41c-080100efa056)


![image](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/5800f8ee-004e-4159-9753-5c0e85fbc548)

</details>
