### PR TITLE
Revert "#2516 » Guide page > 'On this page' side menu > change heading"

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/anchor-nav/anchor-nav.html
+++ b/rca/project_styleguide/templates/patterns/molecules/anchor-nav/anchor-nav.html
@@ -1,10 +1,5 @@
   <div class="anchor-nav" data-anchor-nav>
-    <h2 class="anchor-nav__heading">
-        Jump to
-        <svg width="12" height="8" class="jump-nav__heading-icon" aria-hidden="true">
-            <use xlink:href="#arrow"></use>
-        </svg>
-    </h2>
+    <h2 class="anchor-nav__heading">On this page</h2>
     <nav class="anchor-nav__nav-container">
       <ul class="anchor-nav__items">
         {% for item in anchor_nav %}


### PR DESCRIPTION
Reverts torchbox/rca-wagtail-2019#953

because this was accidentally merged in