### PR TITLE
#2516 » Guide page > 'On this page' side menu > change heading

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/anchor-nav/anchor-nav.html
+++ b/rca/project_styleguide/templates/patterns/molecules/anchor-nav/anchor-nav.html
@@ -1,7 +1,9 @@
   <div class="anchor-nav" data-anchor-nav>
     <h2 class="anchor-nav__heading">
-        Jump to
-        <svg width="12" height="8" class="jump-nav__heading-icon" aria-hidden="true">
+        <div class="anchor-nav__heading-label">
+            Jump to
+        </div>
+        <svg width="12" height="8" class="anchor-nav__heading-icon" aria-hidden="true">
             <use xlink:href="#arrow"></use>
         </svg>
     </h2>

--- a/rca/project_styleguide/templates/patterns/molecules/anchor-nav/anchor-nav.html
+++ b/rca/project_styleguide/templates/patterns/molecules/anchor-nav/anchor-nav.html
@@ -1,5 +1,10 @@
   <div class="anchor-nav" data-anchor-nav>
-    <h2 class="anchor-nav__heading">On this page</h2>
+    <h2 class="anchor-nav__heading">
+        Jump to
+        <svg width="12" height="8" class="jump-nav__heading-icon" aria-hidden="true">
+            <use xlink:href="#arrow"></use>
+        </svg>
+    </h2>
     <nav class="anchor-nav__nav-container">
       <ul class="anchor-nav__items">
         {% for item in anchor_nav %}

--- a/rca/static_src/sass/components/_anchor-nav.scss
+++ b/rca/static_src/sass/components/_anchor-nav.scss
@@ -17,16 +17,29 @@
 
     &__heading {
         display: none;
+
         @include media-query(large) {
-            display: block;
+            display: inline-flex;
+            align-items: center;
             opacity: 0.7;
             margin-bottom: ($gutter * 1.5);
         }
+    }
+
+    &__heading-label {
+        margin-right: 10px;
     }
 
     &__items {
         @include media-query(large) {
             padding-right: $gutter;
         }
+    }
+
+    &__heading-icon {
+        transform: rotate(90deg) translateZ(0);
+        fill: $color--white-65;
+        width: 15px;
+        height: auto;
     }
 }


### PR DESCRIPTION
[Ticket](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2516)

This PR changes the `anchor-nav` heading text to match that of the `jump-nav`.

<details>
  <summary>Before</summary>

![image](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/20733fb2-8a47-4d47-8622-3e30a3650620)

![image](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/9474af77-3173-4b1a-9c96-b631caa3bf6d)

</details>

<details>
  <summary>After</summary>

![image](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/4088425b-efcb-484b-a41c-080100efa056)


![image](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/5800f8ee-004e-4159-9753-5c0e85fbc548)

</details>
