### PR TITLE
Switch from Nodesource scripts to nvm for installing Node.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,14 +108,17 @@ FROM production as dev
 # Swap user, so the following tasks can be run as root
 USER root
 
-# Install node (Keep the version in sync with the node container above)
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && apt-get install -y nodejs
-
 # Install `psql`, useful for `manage.py dbshell`
 RUN apt-get install -y postgresql-client
 
 # Restore user
 USER rca
+
+# Install nvm and node/npm
+ARG NVM_VERSION=0.39.5
+COPY --chown=rca .nvmrc ./
+RUN curl https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh | bash \
+    && bash --login -c "nvm install --no-progress && nvm alias default $(nvm run --silent --version)"
 
 # Pull in the node modules for the frontend
 COPY --chown=rca --from=frontend ./node_modules ./node_modules

--- a/docker/bashrc.sh
+++ b/docker/bashrc.sh
@@ -7,4 +7,10 @@ if [ "$BUILD_ENV" = "dev" ]; then
     alias djtest="python manage.py test --settings=rca.settings.test"
 fi
 
+# nvm
+if [ -a "$HOME/.nvm/nvm.sh" ]; then
+  export NVM_DIR="$HOME/.nvm"
+  source "$NVM_DIR/nvm.sh"
+fi
+
 alias honcho="honcho -f docker/Procfile"


### PR DESCRIPTION
[Support Ticket](https://torchbox.monday.com/boards/1143413211/pulses/1270337485)

### Description of Changes Made

Nodesource will [no longer be using the installation scripts](https://github.com/nodesource/distributions/issues/1438#issuecomment-1698006396) that we've been using for a while. You've probably already come across the deprecation notice when buiding containers:

```console
  This script, located at https://deb.nodesource.com/setup_X, used to
  install Node.js is deprecated now and will eventually be made inactive.

  Please visit the NodeSource distributions Github and follow the
  instructions to migrate your repo.
  https://github.com/nodesource/distributions 

  The NodeSource Node.js Linux distributions GitHub repository contains
  information about which versions of Node.js and which Linux distributions
  are supported and how to install it.
  https://github.com/nodesource/distributions
```

Rather than switching to the [new installation process](https://github.com/nodesource/distributions#installation-instructions), this MR updates the setup to use [nvm](https://github.com/nvm-sh/nvm).

### How to Test

Follow the build instructions in the README. Once the containers are built, SSH into the `web` container via `fab sh` and check that `node` and `npm` commands are available, for instance:

```
node -v
npm -v
```