### PR TITLE
Fix/google spam

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,2 @@
 User-Agent: *
-Disallow: /search/
 Allow: /

--- a/rca/project_styleguide/templates/patterns/base.html
+++ b/rca/project_styleguide/templates/patterns/base.html
@@ -12,6 +12,9 @@
         {% if request.in_preview_panel %}
             <base target="_blank">
         {% endif %}
+        {% if SEO_NOINDEX %}
+            <meta name="robots" content="noindex" />
+        {% endif %}
 
         {% block extra_css %}{% endblock %}
 

--- a/rca/search/views.py
+++ b/rca/search/views.py
@@ -34,7 +34,11 @@ def search(request):
     response = TemplateResponse(
         request,
         "patterns/pages/search/search.html",
-        {"search_query": search_query, "search_results": search_results},
+        {
+            "search_query": search_query,
+            "search_results": search_results,
+            "SEO_NOINDEX": True,
+        },
     )
     # Instruct FE cache to not cache when the search query is present.
     # It's so hits get added to the database and results include newly


### PR DESCRIPTION
Addresses the Google spam issue as recommended on [this doc](https://docs.google.com/document/d/1sZ2q6KbiXtpIA89zQHpPC5PuTq9dl0XGr7DyzGtWmWA/edit):

- Adds a noindex meta tag to the search page
- Removes the search page disallow from robots.txt, to allow Google to pick up on the noindex change