### PR TITLE
№ 2524 - Site search > Crawling accordion content

### DIFF
--- a/rca/programmes/models.py
+++ b/rca/programmes/models.py
@@ -803,6 +803,7 @@ class ProgrammePage(TapMixin, ContactFieldsMixin, BasePage):
         # for content in the 'accordion_snippet' block, we index a custom function
         # https://docs.wagtail.org/en/v5.1.3/topics/search/indexing.html#indexing-callables-and-other-attributes
         index.SearchField("get_requirements_blocks_accordion_snippet"),
+        index.SearchField("scholarship_accordion_items"),
         index.SearchField("scholarship_information_blocks"),
         index.SearchField("more_information_blocks", boost=2),
         index.RelatedFields("programme_type", [index.SearchField("display_name")]),

--- a/rca/programmes/utils.py
+++ b/rca/programmes/utils.py
@@ -1,3 +1,8 @@
+from itertools import chain
+
+from rca.utils.models import AccordionSnippet
+
+
 def format_study_mode(strings, separator=" or "):
     """
     Formats a list of strings by concatenation using the separator.
@@ -41,3 +46,75 @@ def format_study_mode(strings, separator=" or "):
         return result.capitalize()
     else:
         return separator.join(strings).capitalize()
+
+
+def get_accordion_snippet_content(stream_field):
+    """
+    Helper function to extract content from a SnippetChooserBlock (for `AccordionSnippet`s)
+    in a StreamField.
+
+    Args:
+        stream_field (StreamField): A StreamField containing a block of type `accordion_snippet`.
+
+    Returns:
+        str or None: A formatted string containing the "heading," "preview_text," and "body"
+        fields of the matched AccordionSnippet objects. Returns None if the StreamField is empty
+        or does not contain any accordion snippet values.
+
+    Usage:
+        Suppose you have the following:
+
+        ```python
+        requirements_blocks = StreamField(
+            [
+                ("accordion_block", AccordionBlockWithTitle()),
+                ("accordion_snippet", SnippetChooserBlock("utils.AccordionSnippet")),
+            ],
+            blank=True,
+            verbose_name="Accordion blocks",
+            use_json_field=True,
+        )
+        ```
+
+        If you add the `requirements_blocks` StreamField to the search index, the `accordion_snippet`
+        will not be indexed, only the `accordion_block` will be indexed.
+
+        Because we cannot directly index the `accordion_snippet` block in the `requirements_blocks`
+        StreamField, we have to do this manually. This is where this helper function comes in.
+
+        In your Django model, you can define a method that returns the content of the accordion snippet:
+
+        ```python
+        def get_requirements_blocks_accordion_snippet(self):
+            return get_accordion_snippet_content(self.requirements_blocks)
+        ```
+
+        Then add your method to the search index, in addition to the `requirements_blocks` field:
+
+        ```python
+        search_fields = BasePage.search_fields + [
+            # ...,
+            index.SearchField("requirements_blocks"),
+            index.SearchField("get_requirements_blocks_accordion_snippet"),
+            # ...,
+        ]
+        ```
+
+    Reference:
+        https://docs.wagtail.org/en/stable/topics/search/indexing.html#indexing-callables-and-other-attributes
+    """
+    if not stream_field:
+        return None
+
+    data = stream_field.get_prep_value()
+    accordion_snippet_values = [
+        item.get("value") for item in data if item.get("type") == "accordion_snippet"
+    ]
+
+    if not accordion_snippet_values:
+        return None
+
+    accordion_snippet_content = AccordionSnippet.objects.filter(
+        pk__in=accordion_snippet_values
+    ).values_list("heading", "preview_text", "body")
+    return "\n".join(list(chain(*accordion_snippet_content)))

--- a/rca/utils/models.py
+++ b/rca/utils/models.py
@@ -761,8 +761,9 @@ class AccordionSnippet(index.Indexed, OptionalLink):
 
     search_fields = [
         index.SearchField("heading"),
-        index.SearchField("preview_text"),
-        index.SearchField("body"),
+        index.AutocompleteField("heading"),
+        index.AutocompleteField("preview_text"),
+        index.AutocompleteField("body"),
     ]
 
 

--- a/rca/utils/models.py
+++ b/rca/utils/models.py
@@ -23,6 +23,7 @@ from wagtail.api import APIField
 from wagtail.contrib.settings.models import BaseSiteSetting, register_setting
 from wagtail.fields import RichTextField, StreamField
 from wagtail.models import Orderable, Page
+from wagtail.search import index
 from wagtail.snippets.models import register_snippet
 
 from rca.api_content.content import CantPullFromRcaApi, pull_tagged_news_and_events
@@ -728,7 +729,7 @@ class StepSnippet(OptionalLink):
 
 
 @register_snippet
-class AccordionSnippet(OptionalLink):
+class AccordionSnippet(index.Indexed, OptionalLink):
     heading = models.CharField(
         help_text="A large heading diplayed next to the block",
         blank=True,
@@ -757,6 +758,12 @@ class AccordionSnippet(OptionalLink):
         FieldPanel("preview_text"),
         FieldPanel("body"),
     ] + OptionalLink.panels
+
+    search_fields = [
+        index.SearchField("heading"),
+        index.SearchField("preview_text"),
+        index.SearchField("body"),
+    ]
 
 
 @register_snippet


### PR DESCRIPTION
This PR fixes the indexing of the content of Accordion Snippets.

[Ticket](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2524)

Because Accordion Snippets are used on Pages via a SnippetChooserBlock in a StreamField, their content isn't actually part of the StreamField itself. Therefore, searching a Page for values within the Snippets yielded no results.

Attempting to use `index.RelatedFields` will also not work, because there's no relationship between the Page and the `AccordionSnippet`. Therefore, the solution is to write custom functions and index those functions, as indicated in the [Wagtail docs](https://docs.wagtail.org/en/stable/topics/search/indexing.html#indexing-callables-and-other-attributes).

Even though it was not required in this ticket, I have also indexed the `AccordionSnippet` model itself (a62e9c29, 438dab92), so that the snippets are searchable in Wagtail Admin.

<details>
  <summary>Illustration ~ Site Search</summary>

  https://github.com/torchbox/rca-wagtail-2019/assets/7713776/565d52b1-9565-4fde-a6c6-89ef6130cf43

</details>

<details>
  <summary>Illustration ~ Wagtail Admin</summary>
  
https://github.com/torchbox/rca-wagtail-2019/assets/7713776/9334ec28-4ac2-4233-afed-db9aa2671ca6

</details>

> **Note**
> This will require running `./manage.py update_index` on deployment