### PR TITLE
#2526 - Enquire to study form

### DIFF
--- a/rca/enquire_to_study/views.py
+++ b/rca/enquire_to_study/views.py
@@ -279,7 +279,7 @@ class EnquireToStudyFormView(FormView):
         name = f"{form.cleaned_data['first_name']} {form.cleaned_data['last_name']}"
 
         send_mail(
-            f"Enquiry to Study - {name}",
+            f"Enquire to Study - {name}",
             render_to_string(
                 "patterns/emails/enquire_to_study.txt",
                 {"answers": answers, "enquiry_submission": enquiry_submission},

--- a/rca/project_styleguide/templates/patterns/emails/enquire_to_study.txt
+++ b/rca/project_styleguide/templates/patterns/emails/enquire_to_study.txt
@@ -1,0 +1,4 @@
+Submission ID: {{ enquiry_submission.id }}
+{% for key, value in cleaned_data.items %}
+{{ key|capfirst }}: {{ value|safe }}
+{% endfor %}

--- a/rca/project_styleguide/templates/patterns/emails/enquire_to_study.txt
+++ b/rca/project_styleguide/templates/patterns/emails/enquire_to_study.txt
@@ -1,4 +1,4 @@
 Submission ID: {{ enquiry_submission.id }}
-{% for key, value in cleaned_data.items %}
-{{ key|capfirst }}: {{ value|safe }}
+{% for label, answer in answers.items %}
+{{ label }}: {{ answer|safe }}
 {% endfor %}

--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -779,3 +779,6 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 # v2.16 WAGTAIL_SLIM_SIDEBAR https://docs.wagtail.org/en/latest/releases/2.16.html
 # To avoid the following issue https://github.com/torchbox/rca-wagtail-2019/pull/866
 WAGTAIL_SLIM_SIDEBAR = False
+
+
+ENQUIRE_TO_STUDY_DESTINATION_EMAILS = env.get("ENQUIRE_TO_STUDY_DESTINATION_EMAILS", [])

--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -413,7 +413,6 @@ if "SERVER_EMAIL" in env:
 is_in_shell = len(sys.argv) > 1 and sys.argv[1] in ["shell", "shell_plus"]
 
 if "SENTRY_DSN" in env and not is_in_shell:
-
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
     from sentry_sdk.utils import get_default_release
@@ -781,4 +780,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 WAGTAIL_SLIM_SIDEBAR = False
 
 
-ENQUIRE_TO_STUDY_DESTINATION_EMAILS = env.get("ENQUIRE_TO_STUDY_DESTINATION_EMAILS", [])
+if "ENQUIRE_TO_STUDY_DESTINATION_EMAILS" in env:
+    ENQUIRE_TO_STUDY_DESTINATION_EMAILS = env.get(
+        "ENQUIRE_TO_STUDY_DESTINATION_EMAILS"
+    ).split(",")


### PR DESCRIPTION
Ticket: https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2526

This MR adds the feature of sending an internal email to specified email addresses when a user answers the enquire to study form.