### PR TITLE
№ 2528 | Research Student Accounts > Take off time limit on passwords

### DIFF
--- a/rca/account_management/tests/test_forms.py
+++ b/rca/account_management/tests/test_forms.py
@@ -1,6 +1,11 @@
+import re
+
 from django.contrib.auth.models import Group, Permission
-from django.test import TestCase
+from django.core import mail
+from django.test import TestCase, override_settings
 from django.urls import reverse
+from django.utils import timezone
+from freezegun import freeze_time
 from wagtail.models import Collection, GroupCollectionPermission, GroupPagePermission
 from wagtail_factories import CollectionFactory
 
@@ -13,7 +18,6 @@ from rca.users.models import User
 
 
 class TestStudentAccountCreationForm(TestCase):
-
     view_name = "student_account_create"
 
     def setUp(self):
@@ -123,3 +127,48 @@ class TestStudentAccountCreationForm(TestCase):
         self.assertTrue(page_permission)
         self.assertTrue(edit_collection_permission)
         self.assertTrue(choose_collection_permission)
+
+    @override_settings(PASSWORD_RESET_TIMEOUT=60 * 60 * 24 * 30)
+    def test_email_sent_with_correct_days(self):
+        self.client.force_login(self.user)
+        form_data = self.form_data
+        form_data["create_student_page"] = True
+        self.client.post(reverse(self.view_name), data=form_data)
+
+        self.assertEqual(len(mail.outbox), 1)
+
+        # Check that the email body contains the correct number of days
+        expected_days = "30 days"
+        self.assertIn(
+            f"Note that this link will expire in {expected_days}.", mail.outbox[0].body
+        )
+
+    @override_settings(PASSWORD_RESET_TIMEOUT=60 * 60 * 24 * 30)
+    def test_password_reset_link_expires_after_correct_days(self):
+        self.client.force_login(self.user)
+        form_data = self.form_data
+        form_data["create_student_page"] = True
+        self.client.post(reverse(self.view_name), data=self.form_data)
+
+        email_body = mail.outbox[0].body
+        # get the password reset link from the email body
+        url_pattern = re.compile(r"https?://\S+")
+        matches = url_pattern.findall(email_body)
+        # the assumption is that there's only one link in the email body
+        password_reset_link = matches[0]
+        print(password_reset_link)
+
+        self.client.logout()
+        error_message = b"Invalid password reset link"
+
+        # Check that the password reset link is valid
+        future_date = timezone.now() + timezone.timedelta(days=25)
+        with freeze_time(lambda: future_date):
+            response = self.client.get(password_reset_link)
+            self.assertNotIn(error_message, response.content)
+
+        # Check that the password reset link is invalid after the timeout period
+        future_date = timezone.now() + timezone.timedelta(days=31)
+        with freeze_time(lambda: future_date):
+            response = self.client.get(password_reset_link)
+            self.assertIn(error_message, response.content)

--- a/rca/account_management/views.py
+++ b/rca/account_management/views.py
@@ -131,7 +131,8 @@ class CreateStudentFormView(FormView):
                 {
                     "finish_registration_url": password_reset_url,
                     "user": student_user,
-                    "PASSWORD_RESET_TIMEOUT_DAYS": settings.PASSWORD_RESET_TIMEOUT_DAYS,
+                    "PASSWORD_RESET_TIMEOUT_DAYS": settings.PASSWORD_RESET_TIMEOUT
+                    // (24 * 60 * 60),
                 },
             )
             try:

--- a/rca/account_management/views.py
+++ b/rca/account_management/views.py
@@ -139,7 +139,7 @@ class CreateStudentFormView(FormView):
                 user_notification_sent = send_mail(
                     email_subject,
                     email_body,
-                    "do-not-reply@rca.ac.uk",
+                    settings.RCA_DNR_EMAIL,
                     [student_user.email],
                 )
             except SMTPException:

--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -413,7 +413,6 @@ if "SERVER_EMAIL" in env:
 is_in_shell = len(sys.argv) > 1 and sys.argv[1] in ["shell", "shell_plus"]
 
 if "SENTRY_DSN" in env and not is_in_shell:
-
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
     from sentry_sdk.utils import get_default_release
@@ -752,7 +751,8 @@ MAILCHIMP_PROGRAMMES_INTEREST_CATEGORY_ID = env.get(
     "MAILCHIMP_PROGRAMMES_INTEREST_CATEGORY_ID", None
 )
 
-PASSWORD_RESET_TIMEOUT_DAYS = 5
+# https://docs.djangoproject.com/en/3.2/ref/settings/#password-reset-timeout
+PASSWORD_RESET_TIMEOUT = 60 * 60 * 24 * 90  # 90 days, in seconds, default is 3 days
 
 WAGTAIL_USER_EDIT_FORM = "rca.users.forms.CustomUserEditForm"
 


### PR DESCRIPTION
[Ticket](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2528)

This PR adjusts the password reset timeout to give more time for students to reset their passwords. 

Because `PASSWORD_RESET_TIMEOUT_DAYS` is [deprecated in Django 3.1](https://docs.djangoproject.com/en/3.2/ref/settings/#password-reset-timeout-days), we now use `PASSWORD_RESET_TIMEOUT` instead.