### PR TITLE
2537 - Sticky CTA showing on page load 

### DIFF
--- a/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail.html
+++ b/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail.html
@@ -3,7 +3,7 @@
 {% get_settings %}
 
 {% block body_class %}
-    app--editorial
+    app--editorial sticky-bar
 {% endblock %}
 
 {% block content %}
@@ -19,7 +19,11 @@
             </div>
         {% endif %}
 
-        <header class="page__header bg bg--dark">
+        {% if sticky_cta %}
+            {% include "patterns/molecules/sticky-cta/sticky-cta.html" with item=sticky_cta modal=sticky_cta.modal modal_aria_label="call-to-action-title" %}
+        {% endif %}
+
+        <header class="page__header bg bg--dark{% if sticky_cta %} page__header--with-sticky-cta{% endif %}">
             <div class="title-area title-area--breadcrumb grid">
                 <div class="title-area__content">
                     <nav class="title-area__breadcrumb" aria-label="Breadcrumb">
@@ -82,11 +86,7 @@
 
         </header>
 
-        {% if sticky_cta %}
-            {% include "patterns/molecules/sticky-cta/sticky-cta.html" with item=sticky_cta modal=sticky_cta.modal modal_aria_label="call-to-action-title" %}
-        {% endif %}
-
-        <div class="page__content js-sticky-point js-sticky-point--bottom">
+        <div class="page__content js-sticky-point js-sticky-point--top">
 
             <section class="section bg bg--light">
 

--- a/rca/project_styleguide/templates/patterns/pages/events/event_detail.html
+++ b/rca/project_styleguide/templates/patterns/pages/events/event_detail.html
@@ -3,7 +3,7 @@
 {% get_settings %}
 
 {% block body_class %}
-    app--event-detail
+    app--event-detail sticky-bar
 {% endblock %}
 
 {% block content %}
@@ -20,7 +20,11 @@
             </div>
         {% endif %}
 
-        <header class="page__header bg bg--dark">
+        {% if page.show_booking_bar and not page.past %}
+            {% include "patterns/molecules/booking-bar/booking-bar.html" with item=booking_bar %}
+        {% endif %}
+
+        <header class="page__header bg bg--dark{% if page.show_booking_bar and not page.past %} page__header--with-sticky-cta{% endif %}">
             <div class="title-area title-area--breadcrumb title-area--event grid">
                 <div class="title-area__content">
                     <nav class="title-area__breadcrumb" aria-label="Breadcrumb">
@@ -43,10 +47,6 @@
             {% endif %}
 
         </header>
-
-        {% if page.show_booking_bar and not page.past %}
-            {% include "patterns/molecules/booking-bar/booking-bar.html" with item=booking_bar %}
-        {% endif %}
 
         <div class="page__content js-sticky-point js-sticky-point--bottom">
 

--- a/rca/project_styleguide/templates/patterns/pages/guide/guide.html
+++ b/rca/project_styleguide/templates/patterns/pages/guide/guide.html
@@ -33,17 +33,16 @@
                     </div>
                 </div>
             </div>
-                <div class="introduction introduction--indented grid">
-                    {% if anchor_nav or page.contact_model_image %}
-                        {% include "patterns/molecules/anchor-nav/anchor-nav.html" with anchor_nav=anchor_nav show_contact_block=page.contact_model_image  %}
-                    {% endif %}
-                    <div class="introduction__container">
+            <div class="introduction introduction--indented grid">
+                {% if anchor_nav or page.contact_model_image %}
+                    {% include "patterns/molecules/anchor-nav/anchor-nav.html" with anchor_nav=anchor_nav show_contact_block=page.contact_model_image  %}
+                {% endif %}
+                <div class="introduction__container">
                     {% if page.introduction %}
                         <h2 class="introduction__text section__heading heading heading--five">
                             {{ page.introduction }}
                         </h2>
                     {% endif %}
-                    </div>
                 </div>
             </div>
         </header>

--- a/rca/project_styleguide/templates/patterns/pages/guide/guide.html
+++ b/rca/project_styleguide/templates/patterns/pages/guide/guide.html
@@ -3,7 +3,7 @@
 {% get_settings %}
 
 {% block body_class %}
-    app--guide no-hero
+    app--guide no-hero sticky-cta
 {% endblock %}
 
 {% block tap_widget %}
@@ -14,7 +14,11 @@
 
     <div class="page page--no-hero">
 
-        <header class="page__header bg bg--dark">
+        {% if sticky_cta %}
+            {% include "patterns/molecules/sticky-cta/sticky-cta.html" with item=sticky_cta modal=sticky_cta.modal modal_aria_label="call-to-action-title" %}
+        {% endif %}
+
+        <header class="page__header bg bg--dark{% if sticky_cta %} page__header--with-sticky-cta{% endif %}">
             <div class="title-area title-area--guide grid">
                 <div class="title-area__content">
                     <nav class="title-area__breadcrumb" aria-label="Breadcrumb">
@@ -43,10 +47,6 @@
                 </div>
             </div>
         </header>
-
-        {% if sticky_cta %}
-            {% include "patterns/molecules/sticky-cta/sticky-cta.html" with item=sticky_cta modal=sticky_cta.modal modal_aria_label="call-to-action-title" %}
-        {% endif %}
 
         <div class="page__content js-sticky-point js-sticky-point--bottom">
 

--- a/rca/project_styleguide/templates/patterns/pages/shortcourses/short_course.html
+++ b/rca/project_styleguide/templates/patterns/pages/shortcourses/short_course.html
@@ -3,7 +3,7 @@
 {% get_settings %}
 
 {% block body_class %}
-    app--short-course
+    app--short-course sticky-cta
 {% endblock %}
 
 {% block content %}
@@ -17,7 +17,11 @@
             <div class="page__notch-block bg bg--dark"></div>
         </div>
 
-        <header class="page__header bg bg--dark">
+        {% if booking_bar %}
+            {% include "patterns/molecules/booking-bar/booking-bar.html" with item=booking_bar modal=booking_bar.modal modal_aria_label="booking-details-title" %}
+        {% endif %}
+
+        <header class="page__header bg bg--dark{% if booking_bar %} page__header--with-sticky-cta{% endif %}">
             <div class="title-area title-area--breadcrumb grid">
                 <div class="title-area__content">
                     <nav class="title-area__breadcrumb" aria-label="Breadcrumb">
@@ -32,10 +36,6 @@
                 {% endif %}
             </div>
         </header>
-
-        {% if booking_bar %}
-            {% include "patterns/molecules/booking-bar/booking-bar.html" with item=booking_bar modal=booking_bar.modal modal_aria_label="booking-details-title" %}
-        {% endif %}
 
         <div class="page__content js-sticky-point js-sticky-point--bottom">
 

--- a/rca/static_src/javascript/components/sticky-point.js
+++ b/rca/static_src/javascript/components/sticky-point.js
@@ -13,12 +13,6 @@ function scrollamaInit(position) {
         })
         .onStepEnter(() => {
             document.body.classList.add('sticky-bar');
-        })
-        .onStepExit(() => {
-            // only remove sticky-bar if top
-            if (position === 0) {
-                document.body.classList.remove('sticky-bar');
-            }
         });
 
     // setup resize event

--- a/rca/static_src/sass/components/_page.scss
+++ b/rca/static_src/sass/components/_page.scss
@@ -65,6 +65,14 @@
                 padding-top: ($gutter * 12);
             }
         }
+
+        &--with-sticky-cta {
+            margin-top: -50px;
+
+            @include media-query(medium) {
+                margin-top: -91px;
+            }
+        }
     }
 
     &__notch-block {


### PR DESCRIPTION
Ticket: https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2537

An MR to change the behaviour of the sticky banner so that instead of having to scroll a little before it appears it it shown on page load stuck to the bottom of the page. This has been updated on the following page types:

- Editorial
- Guide
- Event
- Short course

Also removes an extra closing div tag on the guide page.

Demo video of editorial page:

https://github.com/torchbox/rca-wagtail-2019/assets/31627284/c2ad3ec4-fe1e-41f1-976e-dec414f9b3b5

