### PR TITLE
№ 2531 - SPIKE Image focal point selector

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/hero/hero--home.html
+++ b/rca/project_styleguide/templates/patterns/molecules/hero/hero--home.html
@@ -8,7 +8,7 @@
     <img srcset="{{ image_small.url }} 320w,
                  {{ image_medium.url }} 768w,
                  {{ image_large.url }} 1440w"
-                 sizes="(max-width: 598px) 290px,
+                 sizes="(max-width: 598px) 340px,
                         (max-width: 1022px) and (min-width: 599px) 768px,
                         (min-width: 1023px) 1440px"
                  src="{{ image_large.url }}"

--- a/rca/project_styleguide/templates/patterns/molecules/hero/hero--home.html
+++ b/rca/project_styleguide/templates/patterns/molecules/hero/hero--home.html
@@ -8,7 +8,7 @@
     <img srcset="{{ image_small.url }} 320w,
                  {{ image_medium.url }} 768w,
                  {{ image_large.url }} 1440w"
-                 sizes="(max-width: 598px) 340px,
+                 sizes="(max-width: 598px) 320px,
                         (max-width: 1022px) and (min-width: 599px) 768px,
                         (min-width: 1023px) 1440px"
                  src="{{ image_large.url }}"

--- a/rca/static_src/sass/components/_hero.scss
+++ b/rca/static_src/sass/components/_hero.scss
@@ -3,7 +3,7 @@
     overflow: hidden;
 
     &--medium {
-        max-height: 290px;
+        max-height: 340px;
 
         @include media-query(medium) {
             max-height: 536px;
@@ -33,13 +33,12 @@
 
     &__image {
         width: 100%;
-        height: 100vh;
+        height: 100%;
         object-fit: cover;
-        min-height: 340px;
+        min-height: 290px;
 
         @include media-query(medium) {
             min-height: 450px;
-            height: 100%;
         }
 
         @include media-query(large) {


### PR DESCRIPTION
[ticket](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2531)

On mobile devices, the hero image cropping doesn't respect the focal point defined on the image in Wagtail Admin. This PR attempts to fix this by adjusting the size of the image being cropped, so that we are cropping the correct region.

### Illustration

<details>
  <summary>Image focal point</summary>

![image](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/072cb106-3dd7-49f4-828e-fec2c45b8e16)

</details>

<details>
  <summary>Before</summary>

![image](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/694b2cbc-612e-4fde-9689-cfa9507f2c5d)

</details>

<details>
  <summary>After</summary>

![image](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/f8aa311a-d6ac-4114-8e00-3b6753be1250)

</details>
