### PR TITLE
Makes time travel impossible to publish

### DIFF
--- a/rca/events/factories.py
+++ b/rca/events/factories.py
@@ -45,7 +45,7 @@ class EventDetailPageFactory(wagtail_factories.PageFactory):
     title = factory.Faker("text", max_nb_chars=25)
     introduction = factory.Faker("text", max_nb_chars=150)
     start_date = factory.Faker("date")
-    end_date = factory.Faker("date")
+    end_date = factory.Faker("date_time_between", start_date="+2d", end_date="+4d")
     event_type = factory.SubFactory(EventTypeFactory)
     eligibility = factory.SubFactory(EventEligibilityFactory)
     location = factory.SubFactory(EventLocationFactory)

--- a/rca/events/models.py
+++ b/rca/events/models.py
@@ -726,12 +726,12 @@ class EventDetailPage(ContactFieldsMixin, BasePage):
                 {"end_time": "The end time must come after the start time."}
             )
         if self.end_date < self.start_date:
-             raise ValidationError(
-                 {
-                     "start_date": "The start date must come before the end date.",
-                     "end_date": "The end date must come after the start date.",
-                 }
-             )
+            raise ValidationError(
+                {
+                    "start_date": "The start date must come before the end date.",
+                    "end_date": "The end date must come after the start date.",
+                }
+            )
 
     def get_series_events(self):
         today = datetime.date.today()

--- a/rca/events/models.py
+++ b/rca/events/models.py
@@ -725,6 +725,10 @@ class EventDetailPage(ContactFieldsMixin, BasePage):
             raise ValidationError(
                 {"end_time": "The end time must come after the start time."}
             )
+        if self.end_date < self.start_date:
+            raise ValidationError(
+                {"end_date": "The end date must come after the start date."}
+            )
 
     def get_series_events(self):
         today = datetime.date.today()

--- a/rca/events/models.py
+++ b/rca/events/models.py
@@ -726,9 +726,12 @@ class EventDetailPage(ContactFieldsMixin, BasePage):
                 {"end_time": "The end time must come after the start time."}
             )
         if self.end_date < self.start_date:
-            raise ValidationError(
-                {"end_date": "The end date must come after the start date."}
-            )
+             raise ValidationError(
+                 {
+                     "start_date": "The start date must come before the end date.",
+                     "end_date": "The end date must come after the start date.",
+                 }
+             )
 
     def get_series_events(self):
         today = datetime.date.today()

--- a/rca/events/tests/test_models.py
+++ b/rca/events/tests/test_models.py
@@ -283,6 +283,36 @@ class EventDetailPageDateTests(WagtailPageTestCase):
         self.assertEqual(1, len(the_exception.messages))
         self.assertEqual(message, the_exception.messages[0])
 
+    def test_event_date_validation(self):
+        start_date = date(2024, 2, 1)
+        end_date = date(2024, 1, 1)
+        with self.subTest(
+            f"Testing date validation: start date: {start_date}, end date: {end_date}",
+            start_date=start_date,
+            end_date=end_date,
+        ):
+            with self.assertRaises(ValidationError) as cm:
+                EventDetailPageFactory.build(
+                    start_date=start_date,
+                    end_date=end_date,
+                    path="0",
+                    depth=0,
+                    event_type=EventTypeFactory(),
+                    location=EventLocationFactory(),
+                    eligibility=EventEligibilityFactory(),
+                ).full_clean()
+
+            the_exception = cm.exception
+            self.assertEqual(2, len(the_exception.messages))
+            self.assertEqual(
+                "The start date must come before the end date.",
+                the_exception.messages[0],
+            )
+            self.assertEqual(
+                "The end date must come after the start date.",
+                the_exception.messages[1],
+            )
+
 
 class EventDetailPageRelatedContentTests(WagtailPageTestCase):
     """


### PR DESCRIPTION
There was a [bug](https://torchbox.monday.com/boards/1318157635/pulses/1319720954/posts/163028834) reported that events were not showing in the events index, on inspection this looks like some end dates have been published before the start date, by accident. So this should ensure that is no longer possible.