### PR TITLE
№ 2547 » Programmes to display degree level in the Enquiry form submissions spreadsheet

### DIFF
--- a/rca/enquire_to_study/views.py
+++ b/rca/enquire_to_study/views.py
@@ -273,8 +273,8 @@ class EnquireToStudyFormView(FormView):
             ]
         )
 
-        # Transform programmes into titles since it's going to be a QuerySet.
-        answers["Programmes"] = ", ".join([p.title for p in answers["Programmes"]])
+        # Transform programmes into their string representation since it's going to be a QuerySet.
+        answers["Programmes"] = ", ".join([str(p) for p in answers["Programmes"]])
 
         name = f"{form.cleaned_data['first_name']} {form.cleaned_data['last_name']}"
 

--- a/rca/enquire_to_study/wagtail_hooks.py
+++ b/rca/enquire_to_study/wagtail_hooks.py
@@ -59,8 +59,7 @@ class EnquiryFormSubmissionAdmin(ModelAdmin):
 
     def get_programmes(self, obj):
         return ", ".join(
-            str(item.programme.title)
-            for item in obj.enquiry_submission_programmes.all()
+            str(item.programme) for item in obj.enquiry_submission_programmes.all()
         )
 
     get_programmes.short_description = "Programmes"


### PR DESCRIPTION
Ticket: [№ 2547 » BE | Register your interest form > CSV download](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2547)

In this PR, a small change is made to the way programmes are displayed in the enquiry form submission, so that the degree level is appended to the title.

Since `ProgrammePage`s' string representation [already handles this](https://github.com/torchbox/rca-wagtail-2019/blob/b8204123533644f287a9a52415c801fa8e169728/rca/programmes/models.py#L894-L898), we make use of it by just calling `item.programme`.

<details><summary>Before</summary>

![image](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/6baf1ff1-a3aa-4dce-b2df-e7bdad223fba)

![image](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/2bf0f2ac-544f-4723-acaa-7470c41de7aa)

</details> 

<details><summary>After</summary>

![image](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/5b46b632-5201-4de1-9482-c772691a7aaf)

![image](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/821936f1-d239-4b2e-a8df-c2f121802925)

</details> 


