### PR TITLE
#2540 - FE | Site-wide > Large CTAs > Bug affecting display

### DIFF
--- a/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail.html
+++ b/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail.html
@@ -156,7 +156,7 @@
                 {% endif %}
 
                 {% if page.contact_model_image or page.contact_model_text or page.contact_model_email or page.contact_model_url or page.contact_model_form %}
-                    <div class="section__row section__row--first">
+                    <div class="section__row section__row--first{% if not hero_image %} section--extra-margin-bottom{% endif %}">
                         {% include "patterns/organisms/contact/contact.html" with heading=page.contact_model_title text=page.contact_model_text image=page.contact_model_image %}
                     </div>
                 {% endif %}

--- a/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail.html
+++ b/rca/project_styleguide/templates/patterns/pages/editorial/editorial_detail.html
@@ -156,7 +156,7 @@
                 {% endif %}
 
                 {% if page.contact_model_image or page.contact_model_text or page.contact_model_email or page.contact_model_url or page.contact_model_form %}
-                    <div class="section__row section__row--first{% if not hero_image %} section--extra-margin-bottom{% endif %}">
+                    <div class="section__row section__row--first{% if not hero_image %} section--extra-margin-bottom{% elif hero_image and sticky_cta %} section--extra-padding-bottom{% endif %}">
                         {% include "patterns/organisms/contact/contact.html" with heading=page.contact_model_title text=page.contact_model_text image=page.contact_model_image %}
                     </div>
                 {% endif %}

--- a/rca/project_styleguide/templates/patterns/pages/guide/guide.html
+++ b/rca/project_styleguide/templates/patterns/pages/guide/guide.html
@@ -98,7 +98,7 @@
             {% if page.contact_model_image or page.contact_model_text or page.contact_model_email or page.contact_model_url or page.contact_model_form %}
                 <section class="section bg bg--light">
                     <div class="contact-anchor anchor-heading" id="contact"></div>
-                    <div class="section__row section__row--first">
+                    <div class="section__row section__row--first section--extra-margin-bottom">
                         {% include "patterns/organisms/contact/contact.html" with heading=page.contact_model_title text=page.contact_model_text image=page.contact_model_image anchor_heading=True %}
                     </div>
                 </section>

--- a/rca/static_src/sass/components/_booking-bar.scss
+++ b/rca/static_src/sass/components/_booking-bar.scss
@@ -103,4 +103,12 @@
             }
         }
     }
+
+    .app--editorial & {
+        &-last-item {
+            @include media-query(large) {
+                margin-bottom: -($gutter * 13.5);
+            }
+        }
+    }
 }

--- a/rca/static_src/sass/components/_section.scss
+++ b/rca/static_src/sass/components/_section.scss
@@ -159,6 +159,16 @@
         }
     }
 
+    &--extra-padding-bottom {
+        @include media-query(medium) {
+            padding-bottom: $notch-height-medium;
+        }
+
+        @include media-query(large) {
+            padding-bottom: $notch-height-large;
+        }
+    }
+
     &__header {
         &--bottom-space {
             margin-bottom: ($gutter * 2);

--- a/rca/static_src/sass/components/_section.scss
+++ b/rca/static_src/sass/components/_section.scss
@@ -149,6 +149,16 @@
         }
     }
 
+    &--extra-margin-bottom {
+        @include media-query(medium) {
+            margin-bottom: $notch-height-medium;
+        }
+
+        @include media-query(large) {
+            margin-bottom: $notch-height-large;
+        }
+    }
+
     &__header {
         &--bottom-space {
             margin-bottom: ($gutter * 2);


### PR DESCRIPTION
Ticket: https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2540

This PR fixes an issue where the CTA is cut when it's at the very bottom of the page and that there is no hero image. This doesn't happen all the time though so I've checked pages which uses the `contact.html`.

Screenshots using the provided links in the ticket:

<img width="1912" alt="1" src="https://github.com/torchbox/rca-wagtail-2019/assets/13232547/e653d093-f2ec-4fc7-bd55-cb2f90baf721">
<img width="1912" alt="2" src="https://github.com/torchbox/rca-wagtail-2019/assets/13232547/cbc959e9-956b-441b-a94b-d7430b6eda4c">
