### PR TITLE
#2549 - FE | Staff Index > Qualification level not appearing in programme filter

### DIFF
--- a/rca/editorial/models.py
+++ b/rca/editorial/models.py
@@ -26,6 +26,7 @@ from rca.events.serializers import (
 )
 from rca.people.filter import SchoolCentreDirectorateFilter
 from rca.people.models import Directorate
+from rca.programmes.filter import ProgrammeStyleFilter
 from rca.research.models import ResearchCentrePage
 from rca.schools.models import SchoolPage
 from rca.utils.blocks import (
@@ -538,7 +539,7 @@ class EditorialListingPage(ContactFieldsMixin, BasePage):
                 filter_by="editorial_types__type__slug__in",
                 option_value_field="slug",
             ),
-            TabStyleFilter(
+            ProgrammeStyleFilter(
                 "Programme",
                 queryset=(
                     ProgrammePage.objects.filter(

--- a/rca/people/models.py
+++ b/rca/people/models.py
@@ -35,6 +35,7 @@ from rca.people.filter import SchoolCentreDirectorateFilter
 from rca.people.formatters import format_research_highlights
 from rca.people.utils import get_staff_research_projects, get_student_research_projects
 from rca.programmes.models import ProgrammePage
+from rca.programmes.filter import ProgrammeStyleFilter
 from rca.research.models import ResearchCentrePage
 from rca.schools.models import SchoolPage
 from rca.users.models import User
@@ -514,7 +515,7 @@ class StaffIndexPage(BasePage):
                     )
                 ),
             ),
-            TabStyleFilter(
+            ProgrammeStyleFilter(
                 "Programme",
                 queryset=(
                     ProgrammePage.objects.live().filter(
@@ -524,6 +525,7 @@ class StaffIndexPage(BasePage):
                     )
                 ),
                 filter_by="roles__programme__slug__in",
+                option_label_field="",
                 option_value_field="slug",
             ),
             TabStyleFilter(

--- a/rca/people/models.py
+++ b/rca/people/models.py
@@ -34,8 +34,8 @@ from rca.api_content.content import CantPullFromRcaApi, pull_related_students
 from rca.people.filter import SchoolCentreDirectorateFilter
 from rca.people.formatters import format_research_highlights
 from rca.people.utils import get_staff_research_projects, get_student_research_projects
-from rca.programmes.models import ProgrammePage
 from rca.programmes.filter import ProgrammeStyleFilter
+from rca.programmes.models import ProgrammePage
 from rca.research.models import ResearchCentrePage
 from rca.schools.models import SchoolPage
 from rca.users.models import User
@@ -525,7 +525,6 @@ class StaffIndexPage(BasePage):
                     )
                 ),
                 filter_by="roles__programme__slug__in",
-                option_label_field="",
                 option_value_field="slug",
             ),
             TabStyleFilter(

--- a/rca/programmes/filter.py
+++ b/rca/programmes/filter.py
@@ -1,5 +1,6 @@
 from rca.utils.filter import TabStyleFilter
 
+
 class ProgrammeStyleFilter(TabStyleFilter):
     """
     Custom TabStyleFilter class for ProgrammePages since we want to display the
@@ -7,7 +8,10 @@ class ProgrammeStyleFilter(TabStyleFilter):
     """
 
     def __iter__(self):
-        values = [(programme.slug, str(programme)) for programme in self.queryset.order_by("slug")]
+        values = [
+            (getattr(programme, self.option_value_field), str(programme))
+            for programme in self.queryset.order_by(self.option_value_field)
+        ]
 
         for value, label in values:
             yield dict(

--- a/rca/programmes/filter.py
+++ b/rca/programmes/filter.py
@@ -1,0 +1,15 @@
+from rca.utils.filter import TabStyleFilter
+
+class ProgrammeStyleFilter(TabStyleFilter):
+    """
+    Custom TabStyleFilter class for ProgrammePages since we want to display the
+    string representation of the programme instead of just the title.
+    """
+
+    def __iter__(self):
+        values = [(programme.slug, str(programme)) for programme in self.queryset.order_by("slug")]
+
+        for value, label in values:
+            yield dict(
+                id=value, title=label, active=bool(value in self.selected_values)
+            )


### PR DESCRIPTION
Ticket: https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2549

This ticket updates the filter used for programmes. At the moment, it's using just the title. We need the string representation of it.

Screenshot:

<img width="1912" alt="Screenshot 2024-02-29 at 9 38 21 AM" src="https://github.com/torchbox/rca-wagtail-2019/assets/13232547/3e41b5e2-7984-4798-ab9a-9d7e940e8ee8">
