### PR TITLE
#2539 - SPIKE FE Image gallery on mobile view

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/people-carousel/people-carousel.html
+++ b/rca/project_styleguide/templates/patterns/molecules/people-carousel/people-carousel.html
@@ -19,6 +19,7 @@
         </ul>
     </div>
 
+    {# Desktop next/previous buttons #}
     <div class="carousel__controls-group grid" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
         <button class="carousel__button carousel__button--prev button" type="button" aria-label="Previous slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
             <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
@@ -40,6 +41,8 @@
                 {% endif %}
             {% endfor %}
         </div>
+
+        {# Mobile next/previous buttons #}
         <div class="carousel__mobile-controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
             <button class="carousel__button carousel__button--prev button" aria-label="Previous image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">

--- a/rca/project_styleguide/templates/patterns/molecules/people-carousel/people-carousel.html
+++ b/rca/project_styleguide/templates/patterns/molecules/people-carousel/people-carousel.html
@@ -40,6 +40,18 @@
                 {% endif %}
             {% endfor %}
         </div>
+        <div class="carousel__mobile-controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
+            <button class="carousel__button carousel__button--prev button" aria-label="Previous image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
+                <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
+                    <use xlink:href="#arrow-left" />
+                </svg>
+            </button>
+            <button class="carousel__button carousel__button--next button" aria-label="Next image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
+                <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
+                    <use xlink:href="#arrow-right" />
+                </svg>
+            </button>
+        </div>
     </div>
 
 </div>

--- a/rca/project_styleguide/templates/patterns/organisms/carousel/carousel--quotes.html
+++ b/rca/project_styleguide/templates/patterns/organisms/carousel/carousel--quotes.html
@@ -30,5 +30,17 @@
                 {% endwith %}
             {% endfor %}
         </div>
+        <div class="carousel__mobile-controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
+            <button class="carousel__button carousel__button--prev button" aria-label="Previous image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
+                <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
+                    <use xlink:href="#arrow-left" />
+                </svg>
+            </button>
+            <button class="carousel__button carousel__button--next button" aria-label="Next image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
+                <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
+                    <use xlink:href="#arrow-right" />
+                </svg>
+            </button>
+        </div>
     </div>
 </div>

--- a/rca/project_styleguide/templates/patterns/organisms/carousel/carousel--quotes.html
+++ b/rca/project_styleguide/templates/patterns/organisms/carousel/carousel--quotes.html
@@ -9,6 +9,8 @@
                 {% endwith %}
             {% endfor %}
         </ul>
+
+        {# Desktop next/previous buttons #}
         <div class="carousel__controls-group grid" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
             <button class="carousel__button carousel__button--prev button" type="button" aria-label="Previous quote{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
@@ -22,6 +24,7 @@
             </button>
         </div>
     </div>
+
     <div class="carousel__controls">
         <div class="carousel__bullet-container" data-glide-el="controls[nav]" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
             {% for slide in carousel %}
@@ -30,6 +33,8 @@
                 {% endwith %}
             {% endfor %}
         </div>
+
+        {# Mobile next/previous buttons #}
         <div class="carousel__mobile-controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
             <button class="carousel__button carousel__button--prev button" aria-label="Previous image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">

--- a/rca/project_styleguide/templates/patterns/organisms/carousel/carousel--square.html
+++ b/rca/project_styleguide/templates/patterns/organisms/carousel/carousel--square.html
@@ -9,6 +9,8 @@
                 {% endwith %}
             {% endfor %}
         </ul>
+
+        {# Desktop next/previous buttons #}
         <div class="carousel__controls-group grid" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
             <button class="carousel__button carousel__button--prev button" type="button" aria-label="Previous slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
@@ -22,6 +24,7 @@
             </button>
         </div>
     </div>
+
     <div class="carousel__controls">
         <div class="carousel__bullet-container" data-glide-el="controls[nav]" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
             {% for slide in carousel %}
@@ -30,6 +33,8 @@
                 {% endwith %}
             {% endfor %}
         </div>
+
+        {# Mobile next/previous buttons #}
         <div class="carousel__mobile-controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
             <button class="carousel__button carousel__button--prev button" aria-label="Previous image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">

--- a/rca/project_styleguide/templates/patterns/organisms/carousel/carousel--square.html
+++ b/rca/project_styleguide/templates/patterns/organisms/carousel/carousel--square.html
@@ -30,5 +30,17 @@
                 {% endwith %}
             {% endfor %}
         </div>
+        <div class="carousel__mobile-controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
+            <button class="carousel__button carousel__button--prev button" aria-label="Previous image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
+                <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
+                    <use xlink:href="#arrow-left" />
+                </svg>
+            </button>
+            <button class="carousel__button carousel__button--next button" aria-label="Next image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
+                <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
+                    <use xlink:href="#arrow-right" />
+                </svg>
+            </button>
+        </div>
     </div>
 </div>

--- a/rca/project_styleguide/templates/patterns/organisms/carousel/carousel.html
+++ b/rca/project_styleguide/templates/patterns/organisms/carousel/carousel.html
@@ -17,6 +17,8 @@
                 <button class="carousel__bullet" data-glide-dir="={{ forloop.counter }}" aria-label="Slide {{ forloop.counter }}"></button>
             {% endfor %}
         </div>
+
+        {# Desktop controls #}
         <div class="carousel__controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
             <button class="carousel__button carousel__button--prev button" type="button" aria-label="Previous slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
@@ -24,6 +26,20 @@
                 </svg>
             </button>
             <button class="carousel__button carousel__button--next button" type="button" aria-label="Next slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
+                <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
+                    <use xlink:href="#arrow-right" />
+                </svg>
+            </button>
+        </div>
+
+        {# Mobile controls #}
+        <div class="carousel__mobile-controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
+            <button type="button" class="carousel__button carousel__button--prev button" aria-label="Previous image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
+                <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
+                    <use xlink:href="#arrow-left" />
+                </svg>
+            </button>
+            <button type="button" class="carousel__button carousel__button--next button" aria-label="Next image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
                     <use xlink:href="#arrow-right" />
                 </svg>

--- a/rca/project_styleguide/templates/patterns/organisms/carousel/carousel.html
+++ b/rca/project_styleguide/templates/patterns/organisms/carousel/carousel.html
@@ -18,7 +18,7 @@
             {% endfor %}
         </div>
 
-        {# Desktop controls #}
+        {# Desktop next/previous buttons #}
         <div class="carousel__controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
             <button class="carousel__button carousel__button--prev button" type="button" aria-label="Previous slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
@@ -32,7 +32,7 @@
             </button>
         </div>
 
-        {# Mobile controls #}
+        {# Mobile next/previous buttons #}
         <div class="carousel__mobile-controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
             <button type="button" class="carousel__button carousel__button--prev button" aria-label="Previous image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">

--- a/rca/project_styleguide/templates/patterns/organisms/carousel/carousel_api_content.html
+++ b/rca/project_styleguide/templates/patterns/organisms/carousel/carousel_api_content.html
@@ -15,7 +15,7 @@
             {% endfor %}
         </div>
 
-        {# Desktop controls #}
+        {# Desktop next/previous buttons #}
         <div class="carousel__controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
             <button class="carousel__button carousel__button--prev button" type="button" aria-label="Previous slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
@@ -29,7 +29,7 @@
             </button>
         </div>
 
-        {# Mobile controls #}
+        {# Mobile next/previous buttons #}
         <div class="carousel__mobile-controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
             <button type="button" class="carousel__button carousel__button--prev button" aria-label="Previous image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">

--- a/rca/project_styleguide/templates/patterns/organisms/carousel/carousel_api_content.html
+++ b/rca/project_styleguide/templates/patterns/organisms/carousel/carousel_api_content.html
@@ -14,6 +14,8 @@
                 <button class="carousel__bullet" data-glide-dir="={{ forloop.counter }}" aria-label="Slide {{ forloop.counter }}"></button>
             {% endfor %}
         </div>
+
+        {# Desktop controls #}
         <div class="carousel__controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
             <button class="carousel__button carousel__button--prev button" type="button" aria-label="Previous slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
@@ -21,6 +23,20 @@
                 </svg>
             </button>
             <button class="carousel__button carousel__button--next button" type="button" aria-label="Next slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
+                <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
+                    <use xlink:href="#arrow-right" />
+                </svg>
+            </button>
+        </div>
+
+        {# Mobile controls #}
+        <div class="carousel__mobile-controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
+            <button type="button" class="carousel__button carousel__button--prev button" aria-label="Previous image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
+                <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
+                    <use xlink:href="#arrow-left" />
+                </svg>
+            </button>
+            <button type="button" class="carousel__button carousel__button--next button" aria-label="Next image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
                 <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
                     <use xlink:href="#arrow-right" />
                 </svg>

--- a/rca/project_styleguide/templates/patterns/organisms/logo-carousel/logo-carousel.html
+++ b/rca/project_styleguide/templates/patterns/organisms/logo-carousel/logo-carousel.html
@@ -37,4 +37,16 @@
             {% endfor %}
         </div>
     </div>
+    <div class="carousel__mobile-controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
+        <button class="carousel__button carousel__button--prev button" aria-label="Previous image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
+            <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
+                <use xlink:href="#arrow-left" />
+            </svg>
+        </button>
+        <button class="carousel__button carousel__button--next button" aria-label="Next image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
+            <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
+                <use xlink:href="#arrow-right" />
+            </svg>
+        </button>
+    </div>
 </div>

--- a/rca/project_styleguide/templates/patterns/organisms/logo-carousel/logo-carousel.html
+++ b/rca/project_styleguide/templates/patterns/organisms/logo-carousel/logo-carousel.html
@@ -16,6 +16,8 @@
             </li>
         </ul>
     </div>
+
+    {# Desktop next/previous buttons #}
     <div class="carousel__controls-group grid" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
         <button class="carousel__button carousel__button--prev button" type="button" aria-label="Previous slide{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
             <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
@@ -28,6 +30,7 @@
             </svg>
         </button>
     </div>
+
     <div class="carousel__controls">
         <div class="carousel__bullet-container" data-glide-el="controls[nav]" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
             {% for slide in carousel %}
@@ -36,17 +39,19 @@
                 {% endif %}
             {% endfor %}
         </div>
-    </div>
-    <div class="carousel__mobile-controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
-        <button class="carousel__button carousel__button--prev button" aria-label="Previous image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
-            <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
-                <use xlink:href="#arrow-left" />
-            </svg>
-        </button>
-        <button class="carousel__button carousel__button--next button" aria-label="Next image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
-            <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
-                <use xlink:href="#arrow-right" />
-            </svg>
-        </button>
+
+        {# Mobile next/previous buttons #}
+        <div class="carousel__mobile-controls-group" data-glide-el="controls" {% if control_title %}aria-controls="{{ control_title|slugify }}"{% endif %}>
+            <button class="carousel__button carousel__button--prev button" aria-label="Previous image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir="<">
+                <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
+                    <use xlink:href="#arrow-left" />
+                </svg>
+            </button>
+            <button class="carousel__button carousel__button--next button" aria-label="Next image{% if control_title %} for {{ control_title }}{% endif %}" data-glide-dir=">">
+                <svg class="carousel__button-icon" width="46" height="46" aria-hidden="true">
+                    <use xlink:href="#arrow-right" />
+                </svg>
+            </button>
+        </div>
     </div>
 </div>

--- a/rca/static_src/sass/components/_carousel.scss
+++ b/rca/static_src/sass/components/_carousel.scss
@@ -42,6 +42,16 @@
                 left: 0;
                 right: 0;
             }
+
+            &--mobile {
+                display: block;
+                grid-column: 1 / -1;
+                margin: 0 auto;
+
+                @include media-query(large) {
+                    display: none;
+                }
+            }
         }
 
         #{$root}__button {
@@ -222,6 +232,31 @@
 
         @include media-query(large) {
             display: block;
+        }
+    }
+
+    &__mobile-controls-group {
+        display: flex;
+        justify-content: center;
+        gap: $gutter;
+        pointer-events: auto; // ensure prev/next buttons are clickable
+        margin-top: $gutter;
+
+        @include media-query(large) {
+            display: none;
+        }
+
+        &:first-child {
+            margin-right: $gutter;
+        }
+
+        #{$root}__button {
+            position: initial;
+
+            &.glide__arrow--disabled {
+                opacity: 0.3;
+                pointer-events: none;
+            }
         }
     }
 

--- a/rca/static_src/sass/components/_slideshow.scss
+++ b/rca/static_src/sass/components/_slideshow.scss
@@ -32,7 +32,7 @@
         pointer-events: auto; // ensure prev/next buttons are clickable
         grid-column: 1 / -1;
         margin: 0 auto;
-        
+
         @include media-query(large) {
             @include z-index(overlap);
             grid-column: 5;

--- a/rca/static_src/sass/components/_slideshow.scss
+++ b/rca/static_src/sass/components/_slideshow.scss
@@ -19,6 +19,8 @@
     }
 
     &__controls {
+        grid-row-gap: $gutter;
+
         @include media-query(large) {
             position: relative;
             top: -$meta-height;
@@ -27,13 +29,14 @@
     }
 
     &__controls-group {
-        display: none;
-        grid-column: 5;
         pointer-events: auto; // ensure prev/next buttons are clickable
-
+        grid-column: 1 / -1;
+        margin: 0 auto;
+        
         @include media-query(large) {
             @include z-index(overlap);
-            display: block;
+            grid-column: 5;
+            margin: unset;
 
             &::after {
                 @include z-index(under);


### PR DESCRIPTION
Ticket: https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2539

This PR updates the mobile view of carousels/slideshows throughout the build. Previously, it wasn't obvious that users could scroll through the component on mobile/tablet view. We then add the arrows instead to help users know about that.

Screenshots:

![Carousel Main](https://github.com/torchbox/rca-wagtail-2019/assets/13232547/62bbfdad-de3d-4ea0-84f8-8d558aec556f)