### PR TITLE
№ 2547 » BE | Add degree level to programmes in the internal email body

### DIFF
--- a/rca/enquire_to_study/views.py
+++ b/rca/enquire_to_study/views.py
@@ -273,8 +273,8 @@ class EnquireToStudyFormView(FormView):
             ]
         )
 
-        # Transform programmes into titles since it's going to be a QuerySet.
-        answers["Programmes"] = ", ".join([p.title for p in answers["Programmes"]])
+        # Transform programmes into their string representation since it's going to be a QuerySet.
+        answers["Programmes"] = ", ".join([str(p) for p in answers["Programmes"]])
 
         name = f"{form.cleaned_data['first_name']} {form.cleaned_data['last_name']}"
 


### PR DESCRIPTION
[Ticket reference](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2547#update-73443141)

While testing #985, it was observed that the internal emails showed programmes without the degree level. This is a small fix to rectify this.

<details><summary>Here's what the emails now look like</summary>

[![Screenshot](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/5fa74f64-f278-4fd6-93a1-f5b33f3f9ed2)](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/5fa74f64-f278-4fd6-93a1-f5b33f3f9ed2)

</details> 