### PR TITLE
#2550 - SPIKE | Special characters not rendering in listing summary

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/search-result/search-result.html
+++ b/rca/project_styleguide/templates/patterns/molecules/search-result/search-result.html
@@ -12,7 +12,10 @@
             {% endif %}
         {% endwith %}
         {% if pick.description or result.listing_summary or result.search_description or result.introduction %}
+        {# Firstof autoescapes variable values so we need to disable it to render special characters "'" properly. #}
+        {% autoescape off %}
         <p class="search-result__summary layout__@large-start-four layout__span-two body body--one">{% firstof result.search_listing_summary pick.description result.listing_summary result.search_description result.introduction %}</p>
+        {% endautoescape %}
         {% endif %}
         <svg class="search-result__icon" aria-hidden="true">
             <use xlink:href="#arrow-right-filled"></use>

--- a/rca/project_styleguide/templates/patterns/molecules/search-result/search-result.html
+++ b/rca/project_styleguide/templates/patterns/molecules/search-result/search-result.html
@@ -14,7 +14,7 @@
         {% if pick.description or result.listing_summary or result.search_description or result.introduction %}
         {# Firstof autoescapes variable values so we need to disable it to render special characters "'" properly. #}
         {% autoescape off %}
-        <p class="search-result__summary layout__@large-start-four layout__span-two body body--one">{% firstof result.search_listing_summary pick.description result.listing_summary result.search_description result.introduction %}</p>
+        <div class="search-result__summary layout__@large-start-four layout__span-two body body--one">{% firstof result.search_listing_summary pick.description result.listing_summary result.search_description result.introduction|richtext %}</div>
         {% endautoescape %}
         {% endif %}
         <svg class="search-result__icon" aria-hidden="true">


### PR DESCRIPTION
Ticket: https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2550

This PR updates how the search description is displayed. Since we're using `firstof`, special characters are displayed as different characters.