### PR TITLE
№ 2554 | Make Related Research Centres and Related Schools read only for Research Students

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -121,7 +121,7 @@ Wagtail 3 introduced a new [FieldPanel `permission` parameter](https://docs.wagt
 
 Additionally there are some Custom Panels which help to add the `permission` parameter to child FieldPanels and control panel visibility in general.
 
-- [StudentPageInlinePanel](https://github.com/torchbox/rca-wagtail-2019/blob/7e5bb3c9201d8a7b7fa6e0288d4bee0ba1c79f52/rca/people/utils.py#L72)
+- [StudentPageInlinePanel](https://github.com/torchbox/rca-wagtail-2019/blob/7e5bb3c9201d8a7b7fa6e0288d4bee0ba1c79f52/rca/people/utils.py#L72) and its [custom template](https://github.com/torchbox/rca-wagtail-2019/blob/7e5bb3c9201d8a7b7fa6e0288d4bee0ba1c79f52/rca/people/templates/admin/panels/student_page_inline_panel.html)
 - [StudentPagePromoteTab](https://github.com/torchbox/rca-wagtail-2019/blob/7e5bb3c9201d8a7b7fa6e0288d4bee0ba1c79f52/rca/people/utils.py#L86)
 - [StudentPageSettingsTab](https://github.com/torchbox/rca-wagtail-2019/blob/7e5bb3c9201d8a7b7fa6e0288d4bee0ba1c79f52/rca/people/utils.py#L107)
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -121,7 +121,9 @@ Wagtail 3 introduced a new [FieldPanel `permission` parameter](https://docs.wagt
 
 Additionally there are some Custom Panels which help to add the `permission` parameter to child FieldPanels and control panel visibility in general.
 
-- [StudentPageInlinePanel](https://github.com/torchbox/rca-wagtail-2019/blob/7e5bb3c9201d8a7b7fa6e0288d4bee0ba1c79f52/rca/people/utils.py#L72) and its [custom template](https://github.com/torchbox/rca-wagtail-2019/blob/7e5bb3c9201d8a7b7fa6e0288d4bee0ba1c79f52/rca/people/templates/admin/panels/student_page_inline_panel.html)
+- [StudentPageInlinePanel](https://github.com/torchbox/rca-wagtail-2019/blob/7e5bb3c9201d8a7b7fa6e0288d4bee0ba1c79f52/rca/people/utils.py#L72), including the custom templates at the following locations:
+  - `rca/people/templates/admin/panels/student_page_inline_panel.html`
+  - `rca/people/templates/admin/panels/student_page_inline_panel_child.html`
 - [StudentPagePromoteTab](https://github.com/torchbox/rca-wagtail-2019/blob/7e5bb3c9201d8a7b7fa6e0288d4bee0ba1c79f52/rca/people/utils.py#L86)
 - [StudentPageSettingsTab](https://github.com/torchbox/rca-wagtail-2019/blob/7e5bb3c9201d8a7b7fa6e0288d4bee0ba1c79f52/rca/people/utils.py#L107)
 

--- a/rca/people/templates/admin/panels/student_page_inline_panel.html
+++ b/rca/people/templates/admin/panels/student_page_inline_panel.html
@@ -1,3 +1,9 @@
+{% comment %}
+This template is essentially the same as
+https://github.com/wagtail/wagtail/blob/stable/5.2.x/wagtail/admin/templates/wagtailadmin/panels/inline_panel.html
+with the exception that the form fields are only displayed to superusers.
+{% endcomment %}
+
 {% load i18n l10n wagtailadmin_tags %}
 
 {% comment "Always render the formset so the form can be saved" %}{% endcomment %}
@@ -6,47 +12,55 @@
 {% comment "Hide the visibe form fields to non-superusers" %}{% endcomment %}
 {% if request.user.is_superuser %}
 
-    <ul class="multiple" id="id_{{ self.formset.prefix }}-FORMS">
-        {% if self.formset.non_form_errors %}
-            <li class="error-message">
-                {% for error in self.formset.non_form_errors %}
-                    <span>{{ error|escape }}</span>
-                {% endfor %}
-            </li>
-        {% endif %}
+    {% if self.formset.non_form_errors %}
+        <div class="error-message">
+            {% for error in self.formset.non_form_errors %}
+                <span>{{ error|escape }}</span>
+            {% endfor %}
+        </div>
+    {% endif %}
+
+    {% if self.help_text %}
+        {% help_block status="info" %}{{ self.help_text }}{% endhelp_block %}
+    {% endif %}
+
+    <div id="id_{{ self.formset.prefix }}-FORMS">
+        {% comment %}
+
+        Child elements of this div will become orderable elements. Do not place additional
+        "furniture" elements here unless you intend them to be part of the child ordering.
+
+        {% endcomment %}
 
         {% for child in self.children %}
             {% include "wagtailadmin/panels/inline_panel_child.html" %}
         {% endfor %}
-    </ul>
+    </div>
 
-    <template id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">
+    <template id="id_{{ self.formset.prefix }}-EMPTY_FORM_TEMPLATE">
         {% include "wagtailadmin/panels/inline_panel_child.html" with child=self.empty_child %}
     </template>
 
-    <p class="add">
-        <button type="button" class="button bicolor button--icon" id="id_{{ self.formset.prefix }}-ADD">
-            {% icon name="plus" wrapped=1 %}
-            {% blocktrans trimmed with label=self.label|lower %}Add {{ label }}{% endblocktrans %}
-        </button>
-    </p>
+    {# Align with guiding line of the preceding child panel. #}
+    <div class="w-mb-4 -w-ml-4">
+        {% block add_button %}
+            <button type="button" class="button button-small button-secondary chooser__choose-button" id="id_{{ self.formset.prefix }}-ADD">
+                {% icon name=icon|default:"plus-inverse" %}{% blocktrans trimmed with label=self.label|lower %}Add {{ label }}{% endblocktrans %}
+            </button>
+        {% endblock %}
+    </div>
 
-    <script>
-        (function() {
-            var panel = new InlinePanel({
-                formsetPrefix: "id_{{ self.formset.prefix }}",
-                emptyChildFormPrefix: "{{ self.empty_child.form.prefix }}",
-                canOrder: {% if can_order %}true{% else %}false{% endif %},
-                maxForms: {{ self.formset.max_num|unlocalize }}
-            });
-
-            {% for child in self.children %}
-                panel.initChildControls("{{ child.form.prefix }}");
-            {% endfor %}
-            panel.setHasContent();
-            panel.updateMoveButtonDisabledStates();
-            panel.updateAddButtonState();
-        })();
-    </script>
+    {% block js_init %}
+        <script>
+            (function() {
+                var panel = new InlinePanel({
+                    formsetPrefix: "id_{{ self.formset.prefix }}",
+                    emptyChildFormPrefix: "{{ self.empty_child.form.prefix }}",
+                    canOrder: {% if can_order %}true{% else %}false{% endif %},
+                    maxForms: {{ self.formset.max_num|unlocalize }}
+                });
+            })();
+        </script>
+    {% endblock %}
 
 {% endif %}

--- a/rca/people/templates/admin/panels/student_page_inline_panel.html
+++ b/rca/people/templates/admin/panels/student_page_inline_panel.html
@@ -1,7 +1,17 @@
 {% comment %}
-This template is essentially the same as
+NOTE: This template is a modified version of the default Wagtail admin template for inline panels:
 https://github.com/wagtail/wagtail/blob/stable/5.2.x/wagtail/admin/templates/wagtailadmin/panels/inline_panel.html
-with the exception that the form fields are only displayed to superusers.
+
+The purpose of the modifications is to prevent non-superusers from making changes to the inline panels.
+
+Modifications:
+1. conditionally use custom template for child elements (admin/panels/student_page_inline_panel_child.html)
+2. conditionally remove the "Add" button to prevent addition of new child elements
+3. conditionally remove the "Actions" dropdown menu to prevent editing of child elements
+
+TODO: Once InlinePanels have read-only / permissions support, then we can
+remove this template and the inline panel child template and work with the defaults.
+See https://github.com/wagtail/wagtail/issues/8684 for more details on support for permissions in InlinePanels.
 {% endcomment %}
 
 {% load i18n l10n wagtailadmin_tags %}
@@ -9,38 +19,43 @@ with the exception that the form fields are only displayed to superusers.
 {% comment "Always render the formset so the form can be saved" %}{% endcomment %}
 {{ self.formset.management_form }}
 
-{% comment "Hide the visibe form fields to non-superusers" %}{% endcomment %}
-{% if request.user.is_superuser %}
-
-    {% if self.formset.non_form_errors %}
-        <div class="error-message">
-            {% for error in self.formset.non_form_errors %}
-                <span>{{ error|escape }}</span>
-            {% endfor %}
-        </div>
-    {% endif %}
-
-    {% if self.help_text %}
-        {% help_block status="info" %}{{ self.help_text }}{% endhelp_block %}
-    {% endif %}
-
-    <div id="id_{{ self.formset.prefix }}-FORMS">
-        {% comment %}
-
-        Child elements of this div will become orderable elements. Do not place additional
-        "furniture" elements here unless you intend them to be part of the child ordering.
-
-        {% endcomment %}
-
-        {% for child in self.children %}
-            {% include "wagtailadmin/panels/inline_panel_child.html" %}
+{% if self.formset.non_form_errors %}
+    <div class="error-message">
+        {% for error in self.formset.non_form_errors %}
+            <span>{{ error|escape }}</span>
         {% endfor %}
     </div>
+{% endif %}
 
-    <template id="id_{{ self.formset.prefix }}-EMPTY_FORM_TEMPLATE">
-        {% include "wagtailadmin/panels/inline_panel_child.html" with child=self.empty_child %}
-    </template>
+{% if self.help_text %}
+    {% help_block status="info" %}{{ self.help_text }}{% endhelp_block %}
+{% endif %}
 
+<div id="id_{{ self.formset.prefix }}-FORMS">
+    {% comment %}
+
+    Child elements of this div will become orderable elements. Do not place additional
+    "furniture" elements here unless you intend them to be part of the child ordering.
+
+    {% endcomment %}
+
+    {% for child in self.children %}
+        {# Begin: Modification № 1 #}
+        {% if request.user.is_superuser %}
+            {% include "wagtailadmin/panels/inline_panel_child.html" %}
+        {% else %}
+            {% include "admin/panels/student_page_inline_panel_child.html" with can_order=False can_delete=False %}
+        {% endif %}
+        {# End: Modification № 1 #}
+    {% endfor %}
+</div>
+
+<template id="id_{{ self.formset.prefix }}-EMPTY_FORM_TEMPLATE">
+    {% include "wagtailadmin/panels/inline_panel_child.html" with child=self.empty_child %}
+</template>
+
+{# Begin: Modification № 2 #}
+{% if request.user.is_superuser %}
     {# Align with guiding line of the preceding child panel. #}
     <div class="w-mb-4 -w-ml-4">
         {% block add_button %}
@@ -49,18 +64,32 @@ with the exception that the form fields are only displayed to superusers.
             </button>
         {% endblock %}
     </div>
-
-    {% block js_init %}
-        <script>
-            (function() {
-                var panel = new InlinePanel({
-                    formsetPrefix: "id_{{ self.formset.prefix }}",
-                    emptyChildFormPrefix: "{{ self.empty_child.form.prefix }}",
-                    canOrder: {% if can_order %}true{% else %}false{% endif %},
-                    maxForms: {{ self.formset.max_num|unlocalize }}
-                });
-            })();
-        </script>
-    {% endblock %}
-
 {% endif %}
+{# End: Modification № 2 #}
+
+{% block js_init %}
+    <script>
+        (function() {
+            var panel = new InlinePanel({
+                formsetPrefix: "id_{{ self.formset.prefix }}",
+                emptyChildFormPrefix: "{{ self.empty_child.form.prefix }}",
+                canOrder: {% if can_order %}true{% else %}false{% endif %},
+                maxForms: {{ self.formset.max_num|unlocalize }}
+            });
+            {# Begin: Modification № 3 #}
+            {% if not request.user.is_superuser %}
+            {% comment "remove the actions dropdown button to prevent editing" %}
+                https://docs.wagtail.org/en/v5.2.3/reference/pages/panels.html#javascript-dom-events
+            {% endcomment %}
+            document.addEventListener('w-formset:ready', function() {
+                var dropdownDiv = document.querySelector('[data-controller="w-dropdown"]');
+                if (dropdownDiv) {
+                    dropdownDiv.remove();
+                }
+            });
+            {% endif %}
+            {# End: Modification № 3 #}
+        })();
+    </script>
+{% endblock %}
+

--- a/rca/people/templates/admin/panels/student_page_inline_panel_child.html
+++ b/rca/people/templates/admin/panels/student_page_inline_panel_child.html
@@ -1,0 +1,42 @@
+{% comment %}
+NOTE: This template is a modified version of the default Wagtail admin template for inline panel children:
+https://github.com/wagtail/wagtail/blob/stable/5.2.x/wagtail/admin/templates/wagtailadmin/panels/inline_panel_child.html
+
+Modification(s):
+- add `{% if can_delete %}` around the delete button to prevent it being shown when the user doesn't have permission to delete
+
+TODO: Once InlinePanels have read-only / permissions support, then we can
+remove this template and its parent and work with the defaults.
+See https://github.com/wagtail/wagtail/issues/8684 for more details on support for permissions in InlinePanels.
+{% endcomment %}
+
+{% load i18n wagtailadmin_tags %}
+
+{% fragment as id %}inline_child_{{ child.form.prefix }}{% endfragment %}
+{% fragment as panel_id %}{{ id }}-panel{% endfragment %}
+<div data-inline-panel-child id="{{ id }}" data-contentpath-disabled>
+    {% fragment as header_controls %}
+        {% if can_order %}
+            <button type="button" class="button button--icon text-replace white" data-inline-panel-child-move-up title="{% trans 'Move up' %}">{% icon name="arrow-up" %}</button>
+            <button type="button" class="button button--icon text-replace white" data-inline-panel-child-move-down title="{% trans 'Move down' %}">{% icon name="arrow-down" %}</button>
+        {% endif %}
+        {% if can_delete %}
+            <button type="button" class="button button--icon text-replace white" id="{{ child.form.DELETE.id_for_label }}-button" title="{% trans 'Delete' %}">{% icon name="bin" %}</button>
+        {% endif %}
+    {% endfragment %}
+    {% fragment as heading %}
+        {{ self.label }}<span data-inline-panel-child-count></span>
+    {% endfragment %}
+    {% panel id=panel_id heading=heading heading_size="label" heading_level="3" header_controls=header_controls %}
+        {% if child.form.non_field_errors %}
+            <ul>
+                {% for error in child.form.non_field_errors %}
+                    <li class="error-message">
+                        <span>{{ error|escape }}</span>
+                    </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+        {{ child.render_form_content }}
+    {% endpanel %}
+</div>

--- a/rca/people/utils.py
+++ b/rca/people/utils.py
@@ -82,7 +82,7 @@ class StudentPageInlinePanel(InlinePanel):
             # Collapse the panel for non-superusers
 
             if not self.request.user.is_superuser and "collapsed" not in panel_class:
-                self.panel.classname = "collapsed"
+                self.panel.classname += " collapsed"
             elif self.request.user.is_superuser and "collapsed" in panel_class:
                 self.panel.classname = panel_class.replace("collapsed", "")
 

--- a/rca/people/utils.py
+++ b/rca/people/utils.py
@@ -77,6 +77,15 @@ class StudentPageInlinePanel(InlinePanel):
             super().__init__(**kwargs)
             self.template_name = "admin/panels/student_page_inline_panel.html"
 
+            panel_class = self.panel.classname
+
+            # Collapse the panel for non-superusers
+
+            if not self.request.user.is_superuser and "collapsed" not in panel_class:
+                self.panel.classname = "collapsed"
+            elif self.request.user.is_superuser and "collapsed" in panel_class:
+                self.panel.classname = panel_class.replace("collapsed", "")
+
         def get_context_data(self, parent_context=None):
             context = super().get_context_data(parent_context)
             context["request"] = self.request

--- a/rca/people/utils.py
+++ b/rca/people/utils.py
@@ -68,7 +68,9 @@ def get_student_research_projects(page):
 
 
 class StudentPageInlinePanel(InlinePanel):
-    # InlinePanel that only displays content to superusers
+    """
+    InlinePanel that prevents non-superusers from making changes to the content
+    """
 
     class BoundPanel(InlinePanel.BoundPanel):
         def __init__(self, **kwargs):


### PR DESCRIPTION
[Ticket](https://projects.torchbox.com/projects/rca-django-cms-project/tickets/2554)

Hiding the `StudentPageInlinePanel` contents resulted in the following error when the child elements had content, and a non-superuser attempted to save changes to the Page, or preview it:

<details><summary>Traceback</summary>

```console
KeyError: 'related_schools-0-id'
  File "django/utils/datastructures.py", line 84, in __getitem__
    list_ = super().__getitem__(key)
MultiValueDictKeyError: 'related_schools-0-id'
  File "django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "django/views/decorators/cache.py", line 62, in _wrapper_view_func
    response = view_func(request, *args, **kwargs)
  File "django/views/decorators/cache.py", line 62, in _wrapper_view_func
    response = view_func(request, *args, **kwargs)
  File "wagtail/admin/urls/__init__.py", line 173, in wrapper
    return view_func(request, *args, **kwargs)
  File "wagtail/admin/auth.py", line 165, in decorated_view
    response = view_func(request, *args, **kwargs)
  File "django/views/generic/base.py", line 104, in view
    return self.dispatch(request, *args, **kwargs)
  File "wagtail/admin/views/pages/edit.py", line 413, in dispatch
    return super().dispatch(request)
  File "django/views/generic/base.py", line 143, in dispatch
    return handler(request, *args, **kwargs)
  File "wagtail/admin/views/pages/edit.py", line 496, in post
    if self.form.is_valid() and not self.locked_for_user:
  File "wagtail/admin/forms/pages.py", line 179, in is_valid
    return super().is_valid()
  File "modelcluster/forms.py", line 344, in is_valid
    formsets_are_valid = all(formset.is_valid() for formset in self.formsets.values())
  File "modelcluster/forms.py", line 344, in <genexpr>
    formsets_are_valid = all(formset.is_valid() for formset in self.formsets.values())
  File "django/forms/formsets.py", line 384, in is_valid
    self.errors
  File "django/forms/formsets.py", line 366, in errors
    self.full_clean()
  File "django/forms/formsets.py", line 423, in full_clean
    for i, form in enumerate(self.forms):
  File "django/utils/functional.py", line 57, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "django/forms/formsets.py", line 205, in forms
    return [
  File "django/forms/formsets.py", line 206, in <listcomp>
    self._construct_form(i, **self.get_form_kwargs(i))
  File "modelcluster/forms.py", line 24, in _construct_form
    pk = self.data[pk_key]
  File "django/utils/datastructures.py", line 86, in __getitem__
    raise MultiValueDictKeyError(key)
```

</details> 

This PR fixes the above by not hiding the contents — we instead display them, but in such a way that non-superusers cannot make any changes.

<details><summary>Screenshot: superuser</summary>

[![Screenshot](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/9a263417-dfae-440b-ac55-ece24b0cafb1)](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/9a263417-dfae-440b-ac55-ece24b0cafb1)

</details> 

<details><summary>Screenshot: non-superuser</summary>

[![Screenshot](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/be61fa00-95ac-459d-b9cb-53426ab4edd5)](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/be61fa00-95ac-459d-b9cb-53426ab4edd5)

</details> 