### PR TITLE
#3879 - Listing pages: duplicates appearing in results

### DIFF
--- a/rca/editorial/models.py
+++ b/rca/editorial/models.py
@@ -552,6 +552,8 @@ class EditorialListingPage(ContactFieldsMixin, BasePage):
         for f in filters:
             queryset = f.apply(queryset, request.GET)
 
+        queryset = queryset.distinct()
+
         # Paginate filtered queryset
         per_page = 12
 


### PR DESCRIPTION
Ticket: https://torchbox.monday.com/boards/1472452416/pulses/1472503879

This PR fixes an issue where duplicate results are shown when doing multiple filters in the editorial listing page. It's a simple fix!