### PR TITLE
#5078 - Accessibility: Content missing after heading

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/card/card.html
+++ b/rca/project_styleguide/templates/patterns/molecules/card/card.html
@@ -15,7 +15,7 @@
                 {% if item.meta %}
                     <div class="card__meta">{{ item.meta }}</div>
                 {% endif %}
-                <h3 class="card__heading">
+                <h4 class="card__heading">
                     {% if item.link %}
                         <span class="card__heading-link">
                             {{ item.title }}
@@ -28,7 +28,7 @@
                     {% else %}
                         {{ item.title }}
                     {% endif %}
-                </h3>
+                </h4>
                 {% if item.description %}
                     <div class="card__description">{{ item.description|safe }}</div>
                 {% endif %}

--- a/rca/project_styleguide/templates/patterns/molecules/card/card_api_content.html
+++ b/rca/project_styleguide/templates/patterns/molecules/card/card_api_content.html
@@ -10,11 +10,11 @@
         <div class="card__content-container">
             <div class="card__content">
                 <div class="card__meta">{{ item.type }}</div>
-                <h3 class="card__heading">
+                <h4 class="card__heading">
                     {% if item.link %}<span class="card__heading-link">{% endif %}
                         {{ item.title }}
                     {% if item.link %}</span>{% endif %}
-                </h3>
+                </h4>
                 <div class="card__description">{% firstof item.formatted_date item.description|richtext %}</div>
             </div>
         </div>

--- a/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.html
+++ b/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.html
@@ -1,12 +1,12 @@
 {% load wagtailcore_tags %}
 <div class="key-details {% if course_type == 'short' %}key-details--short{% endif %}">
     <div class="key-details__header">
-        <h3 class="heading heading--five key-details__heading">Key details</h3>
+        <h4 class="heading heading--five key-details__heading">Key details</h4>
     </div>
     {% if course_type == 'short' %}
         {% if shortcourse_details_fees %}
             <div class="key-details__section key-details__section--fees">
-                <h4 class="body body--two key-details__sub-heading">Fees</h4>
+                <h5 class="body body--two key-details__sub-heading">Fees</h5>
                 <ul class="key-details__list">
                     {% for item in shortcourse_details_fees %}
                     <li class="key-details__list-item">
@@ -18,7 +18,7 @@
         {% endif %}
         {% if page.location %}
             <div class="key-details__section key-details__section--location">
-                <h4 class="body body--two key-details__sub-heading">Location</h4>
+                <h5 class="body body--two key-details__sub-heading">Location</h5>
                 <ul class="key-details__list">
                     <li class="key-details__list-item">
                         {{ page.location|richtext }}
@@ -38,7 +38,7 @@
         {% if page.programme_details_credits or page.programme_details_time or page.study_mode %}
             <div class="key-details__section key-details__section--details">
                 {% if programme_page_global_fields.key_details_programme_details_title %}
-                    <h4 class="body body--two key-details__sub-heading">{{ programme_page_global_fields.key_details_programme_details_title }}</h4>
+                    <h5 class="body body--two key-details__sub-heading">{{ programme_page_global_fields.key_details_programme_details_title }}</h5>
                 {% endif %}
                 <ul class="key-details__list">
                     {% if page.programme_details_credits and page.programme_details_credits_suffix %}
@@ -61,7 +61,7 @@
         {% endif %}
         {% if programme_schools %}
             <div class="key-details__section key-details__section--school">
-                <h4 class="body body--two key-details__sub-heading">School or Centre</h4>
+                <h5 class="body body--two key-details__sub-heading">School or Centre</h5>
                 <ul class="key-details__list">
                     {% for school in programme_schools %}
                     <li class="key-details__list-item">
@@ -73,7 +73,7 @@
         {% endif %}
         {% if page.campus_locations %}
             <div class="key-details__section key-details__section--school">
-                <h4 class="body body--two key-details__sub-heading">Location</h4>
+                <h5 class="body body--two key-details__sub-heading">Location</h5>
                 <ul class="key-details__list">
                     {% for location in page.campus_locations %}
                     <li class="key-details__list-item">
@@ -86,7 +86,7 @@
         {% if page.next_open_day_date or page.link_to_open_days %}
             <div class="key-details__section key-details__section--open-days">
                 {% if programme_page_global_fields.key_details_next_open_day_title %}
-                    <h4 class="body body--two key-details__sub-heading">{{ programme_page_global_fields.key_details_next_open_day_title }}</h4>
+                    <h5 class="body body--two key-details__sub-heading">{{ programme_page_global_fields.key_details_next_open_day_title }}</h5>
                 {% endif %}
                 <ul class="key-details__list">
                     {% if page.next_open_day_date %}
@@ -106,7 +106,7 @@
         {% if page.application_deadline or page.application_deadline_options %}
             <div class="key-details__section key-details__section--deadline">
                 {% if programme_page_global_fields.key_details_application_deadline_title %}
-                    <h4 class="body body--two key-details__sub-heading">{{ programme_page_global_fields.key_details_application_deadline_title }}</h4>
+                    <h5 class="body body--two key-details__sub-heading">{{ programme_page_global_fields.key_details_application_deadline_title }}</h5>
                 {% endif %}
                 <ul class="key-details__list">
                     {% if page.application_deadline_options == '1' %}
@@ -125,7 +125,7 @@
         {% if page.career_opportunities.all %}
             <div class="key-details__section key-details__section--career">
                 {% if programme_page_global_fields.key_details_career_opportunities_title %}
-                    <h4 class="body body--two key-details__sub-heading">{{ programme_page_global_fields.key_details_career_opportunities_title }}</h4>
+                    <h5 class="body body--two key-details__sub-heading">{{ programme_page_global_fields.key_details_career_opportunities_title }}</h5>
                 {% endif %}
                 <ul class="key-details__list">
                 {% for detail in page.career_opportunities.all %}
@@ -144,7 +144,7 @@
         {% endif %}
         {% if social_media_links %}
             <div class="key-details__section key-details__section--social">
-                <h4 class="body body--two key-details__sub-heading">{% firstof page.social_media_links_title "Follow this programme" %}</h4>
+                <h5 class="body body--two key-details__sub-heading">{% firstof page.social_media_links_title "Follow this programme" %}</h5>
                 <ul class="key-details__list">
                     {% for item in social_media_links %}
                         <li class="key-details__list-item">

--- a/rca/project_styleguide/templates/patterns/molecules/profile-detail/profile-detail.html
+++ b/rca/project_styleguide/templates/patterns/molecules/profile-detail/profile-detail.html
@@ -40,7 +40,7 @@
                 </div>
             {% endif %}
             {% if item.role or staff_page %}
-                <h4 class="profile-detail__job-title body body--one" property="schema:jobTitle">{% firstof item.role staff_page.roles.first.role %}</h4>
+                <p class="profile-detail__job-title body body--one" property="schema:jobTitle">{% firstof item.role staff_page.roles.first.role %}</p>
             {% endif %}
         </div>
         <div class="profile-detail__more">

--- a/rca/project_styleguide/templates/patterns/organisms/index-module/index-module.html
+++ b/rca/project_styleguide/templates/patterns/organisms/index-module/index-module.html
@@ -1,7 +1,7 @@
 <div class="index-module">
     <div class="index-module__container grid">
         <div class="index-module__header">
-            <h2 class="index-module__heading heading heading--two {% if anchor_heading %}anchor-heading{% endif %}" {% if anchor_heading %} id="{{ id|slugify }}"{% endif %}>{{ title }}</h2>
+            <h3 class="index-module__heading heading heading--two {% if anchor_heading %}anchor-heading{% endif %}" {% if anchor_heading %} id="{{ id|slugify }}"{% endif %}>{{ title }}</h3>
         </div>
         <div class="index-module__content">
             {% if introduction %}<p class="index-module__introduction body body--one">{{ introduction|striptags }}</p>{% endif %}

--- a/rca/project_styleguide/templates/patterns/pages/guide/guide.html
+++ b/rca/project_styleguide/templates/patterns/pages/guide/guide.html
@@ -39,9 +39,9 @@
                 {% endif %}
                 <div class="introduction__container">
                     {% if page.introduction %}
-                        <h2 class="introduction__text section__heading heading heading--five">
+                        <p class="introduction__text section__heading heading heading--five">
                             {{ page.introduction }}
-                        </h2>
+                        </p>
                     {% endif %}
                 </div>
             </div>
@@ -78,7 +78,7 @@
             {% if page.further_information %}
                 <section class="section bg bg--dark booking-bar-last-item">
                     <div class="section__row section__row--last">
-                            {% include "patterns/organisms/accordion-block/accordion-block.html" with accordion_id='1' accordions=page.further_information course_type="short" title=page.further_information_title anchor_heading=True section_id=page.further_information_title|slugify %}
+                        {% include "patterns/organisms/accordion-block/accordion-block.html" with accordion_id='1' accordions=page.further_information course_type="short" title=page.further_information_title anchor_heading=True section_id=page.further_information_title|slugify %}
                     </div>
                 </section>
             {% endif %}

--- a/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--enterprise.html
+++ b/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--enterprise.html
@@ -59,9 +59,9 @@
                     <div class="section__row section__row--last-large research-highlights">
                         {% if page.highlights_title %}
                             <div class="section__header grid">
-                                <h2 class="section__heading section__heading--primary heading heading--four">
+                                <h3 class="section__heading section__heading--primary heading heading--four">
                                     {{ page.highlights_title }}
-                                </h2>
+                                </h3>
                             </div>
                         {% endif %}
                         <div class="section__content grid">
@@ -99,9 +99,9 @@
                     <div class="section__row research-spaces">
                         <div class="section__header section__header--bottom-space grid">
                         {% if page.related_pages_title %}
-                            <h2 class="section__heading section__heading--tight heading heading--two">
+                            <h3 class="section__heading section__heading--tight heading heading--two">
                                 {{ page.related_pages_title }}
-                            </h2>
+                            </h3>
                         {% endif %}
                         {% if page.related_pages_text %}
                             <div class="section__introduction">

--- a/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--generic.html
+++ b/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--generic.html
@@ -85,9 +85,9 @@
                     <div class="section__row research-spaces">
                         <div class="section__header section__header--bottom-space grid">
                         {% if page.related_pages_title %}
-                            <h2 class="section__heading section__heading--tight heading heading--two">
+                            <h3 class="section__heading section__heading--tight heading heading--two">
                                 {{ page.related_pages_title }}
-                            </h2>
+                            </h3>
                         {% endif %}
                         {% if page.related_pages_text %}
                             <div class="section__introduction">

--- a/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--research.html
+++ b/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--research.html
@@ -59,9 +59,9 @@
                     <div class="section__row section__row--last-large research-highlights">
                         {% if page.highlights_title %}
                             <div class="section__header grid">
-                                <h2 class="section__heading section__heading--primary heading heading--four">
+                                <h3 class="section__heading section__heading--primary heading heading--four">
                                     {{ page.highlights_title }}
-                                </h2>
+                                </h3>
                             </div>
                         {% endif %}
                         <div class="section__content grid">

--- a/rca/project_styleguide/templates/patterns/pages/project/project_detail.html
+++ b/rca/project_styleguide/templates/patterns/pages/project/project_detail.html
@@ -40,9 +40,9 @@
                     <div class="section__content grid">
                         {% if page.introduction %}
                             <div class="project-overview__introduction layout__start-one layout__span-two  layout__@large-start-three layout__@large-span-two">
-                                <h2 class="research-centre-overview__heading section__heading heading heading--five">
+                                <p class="research-centre-overview__heading section__heading heading heading--five">
                                     {{ page.introduction }}
-                                </h2>
+                                </p>
                             </div>
                         {% endif %}
                         <div class="project-overview__content layout__start-one layout__span-two layout__@large-start-two layout__@large-span-three">
@@ -193,9 +193,9 @@
 
                     <div class="section__row section__row--last-large research-highlights">
                         <div class="section__header grid">
-                            <h2 class="section__heading section__heading--primary heading heading--four">
+                            <h3 class="section__heading section__heading--primary heading heading--four">
                                 Related projects
-                            </h2>
+                            </h3>
                         </div>
                         <div class="section__content grid">
                             {% include "patterns/organisms/carousel/carousel.html" with carousel=related_projects modifier='carousel carousel--no-margin' control_title="Related projects carousel" datatag='data-carousel' %}

--- a/rca/project_styleguide/templates/patterns/pages/researchcentre/research_centre.html
+++ b/rca/project_styleguide/templates/patterns/pages/researchcentre/research_centre.html
@@ -67,9 +67,9 @@
                 {% if research_spaces %}
                     <div class="section__row research-spaces">
                         <div class="section__header grid">
-                            <h2 class="section__heading heading heading--four">
+                            <h3 class="section__heading heading heading--four">
                                 Research spaces
-                            </h2>
+                            </h3>
                         </div>
                         <div class="section__content grid">
                             {% include "patterns/organisms/staggered-cards/staggered-cards.html" with staggered_cards=research_spaces %}
@@ -80,9 +80,9 @@
                 {% if projects %}
                     <div class="section__row section__row--last-large research-highlights">
                         <div class="section__header grid">
-                            <h2 class="section__heading section__heading--primary heading heading--four">
+                            <h3 class="section__heading section__heading--primary heading heading--four">
                                 {% firstof page.highlights_title 'Research highlights' %}
-                            </h2>
+                            </h3>
                         </div>
                         <div class="section__content grid">
                             {% include "patterns/organisms/carousel/carousel.html" with carousel=projects modifier='carousel carousel--no-margin' control_title="Related projects carousel" datatag='data-carousel' %}


### PR DESCRIPTION
Ticket: https://torchbox.monday.com/boards/1472452416/pulses/1494025078

This PR fixes "content heading" issues found by Siteimprove. Using the list provided in the ticket, I've checked the pages using the Chrome extension.

There are some that are content managed issues (editors entering 2 h3s in a row in a rich text) so we couldn't do anything about those.