### PR TITLE
#3830 - Accessibility: Landing Page > Featured content module > Link text

### DIFF
--- a/rca/project_styleguide/templates/patterns/organisms/image-video-block/image-video-block.html
+++ b/rca/project_styleguide/templates/patterns/organisms/image-video-block/image-video-block.html
@@ -44,6 +44,9 @@
                         {% if transformation_block.read_more_link_text %}
                             <a href="{{ href }}" class="body body--two link link--tertiary link--link" aria-label="{{ transformation_block.read_more_link_text }}">
                             <span class="link__label">{{ transformation_block.read_more_link_text }}</span>
+                        {% elif link_text %}
+                            <a href="{{ href }}" class="body body--two link link--tertiary link--link" aria-label="{{ link_text }}">
+                            <span class="link__label">{{ link_text }}</span>
                         {% else %}
                             <a href="{{ href }}" class="body body--two link link--tertiary link--link" aria-label="Read more {% if meta_heading %}about {{ meta_heading }}{% endif %}">
                             <span class="link__label">Read more</span>

--- a/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--enterprise.html
+++ b/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--enterprise.html
@@ -126,7 +126,7 @@
             {% if featured_image %}
                 <section class="section bg bg--dark">
                     <div class="section__row section__row--first section__row--last">
-                        {% include "patterns/organisms/image-video-block/image-video-block.html" with modal=false curriculum=false subheading=false has_meta=True heading=featured_image.title meta_heading=featured_image.subtitle meta_copy=featured_image.description href=featured_image.get_link_url image=featured_image.image modifier="tight-heading" %}
+                        {% include "patterns/organisms/image-video-block/image-video-block.html" with modal=false curriculum=false subheading=false has_meta=True heading=featured_image.title meta_heading=featured_image.subtitle meta_copy=featured_image.description href=featured_image.get_link_url link_text=featured_image.get_link_text image=featured_image.image modifier="tight-heading" %}
                     </div>
 
                     <div class="section__notch">

--- a/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--generic.html
+++ b/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--generic.html
@@ -110,7 +110,7 @@
             {% if featured_image %}
                 <section class="section bg bg--dark">
                     <div class="section__row section__row--first section__row--last">
-                        {% include "patterns/organisms/image-video-block/image-video-block.html" with modal=false curriculum=false subheading=false has_meta=True heading=featured_image.title meta_heading=featured_image.subtitle meta_copy=featured_image.description href=featured_image.get_link_url image=featured_image.image modifier="tight-heading" %}
+                        {% include "patterns/organisms/image-video-block/image-video-block.html" with modal=false curriculum=false subheading=false has_meta=True heading=featured_image.title meta_heading=featured_image.subtitle meta_copy=featured_image.description href=featured_image.get_link_url link_text=featured_image.get_link_text image=featured_image.image modifier="tight-heading" %}
                     </div>
 
                     <div class="section__notch">

--- a/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--innovation.html
+++ b/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--innovation.html
@@ -56,7 +56,7 @@
            {% if featured_image %}
                 <section class="section bg bg--dark">
                     <div class="section__row section__row--first section__row--last">
-                        {% include "patterns/organisms/image-video-block/image-video-block.html" with modal=false curriculum=false subheading=false has_meta=True heading=featured_image.title meta_heading=featured_image.subtitle meta_copy=featured_image.description href=featured_image.get_link_url image=featured_image.image modifier="tight-heading" %}
+                        {% include "patterns/organisms/image-video-block/image-video-block.html" with modal=false curriculum=false subheading=false has_meta=True heading=featured_image.title meta_heading=featured_image.subtitle meta_copy=featured_image.description href=featured_image.get_link_url link_text=featured_image.get_link_text image=featured_image.image modifier="tight-heading" %}
                     </div>
                     <div class="section__notch">
                         <div class="section__notch-fill section__notch-fill--third-col"></div>

--- a/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--research.html
+++ b/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--research.html
@@ -101,7 +101,7 @@
             {% if featured_image %}
                 <section class="section bg bg--dark">
                     <div class="section__row section__row--first section__row--last">
-                        {% include "patterns/organisms/image-video-block/image-video-block.html" with modal=false curriculum=false subheading=false has_meta=True heading=featured_image.title meta_heading=featured_image.subtitle meta_copy=featured_image.description href=featured_image.get_link_url image=featured_image.image modifier="tight-heading" %}
+                        {% include "patterns/organisms/image-video-block/image-video-block.html" with modal=false curriculum=false subheading=false has_meta=True heading=featured_image.title meta_heading=featured_image.subtitle meta_copy=featured_image.description href=featured_image.get_link_url link_text=featured_image.get_link_text image=featured_image.image modifier="tight-heading" %}
                     </div>
                     <div class="section__notch">
                         <div class="section__notch-fill section__notch-fill--second-col"></div>

--- a/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--tap.html
+++ b/rca/project_styleguide/templates/patterns/pages/landingpage/landing_page--tap.html
@@ -122,7 +122,7 @@
             {% if featured_image %}
                 <section class="section bg bg--dark">
                     <div class="section__row section__row--first section__row--last">
-                        {% include "patterns/organisms/image-video-block/image-video-block.html" with modal=false curriculum=false subheading=false has_meta=True heading=featured_image.title meta_heading=featured_image.subtitle meta_copy=featured_image.description href=featured_image.get_link_url image=featured_image.image modifier="tight-heading" %}
+                        {% include "patterns/organisms/image-video-block/image-video-block.html" with modal=false curriculum=false subheading=false has_meta=True heading=featured_image.title meta_heading=featured_image.subtitle meta_copy=featured_image.description href=featured_image.get_link_url link_text=featured_image.get_link_text image=featured_image.image modifier="tight-heading" %}
                     </div>
 
                     <div class="section__notch">


### PR DESCRIPTION
Ticket: https://torchbox.monday.com/boards/1472452416/pulses/1472503830

This PR fixes an issue where the link text is not being passed to the image video block. We'll need to update multiple templates as there are multiple pages that uses this `featured_image`.

<img width="1056" alt="Screenshot 2024-05-28 at 4 14 21 PM" src="https://github.com/torchbox/rca-wagtail-2019/assets/13232547/86c9698c-cdb6-4e4f-a34d-ccc9741070dd">
