### PR TITLE
#3836 - Accessibility: STAS-A01: Links to Non-HTML Documents (open in a new tab/window) pg 69

### DIFF
--- a/rca/project_styleguide/templates/patterns/atoms/link-primary/link-primary--download.html
+++ b/rca/project_styleguide/templates/patterns/atoms/link-primary/link-primary--download.html
@@ -1,4 +1,4 @@
 <a class="link link--primary link--download" href="{{ value.href }}">
-    <span class="link__label">{{ value.text }}</span>
+    <span class="link__label">{{ value.text }} ({{ value.file_extension|upper }} {{ value.get_file_size|filesizeformat }})</span>
     <svg width="12" height="8" class="link__icon" aria-hidden="true"><use xlink:href="#download"></use></svg>
 </a>

--- a/rca/project_styleguide/templates/patterns/atoms/link-secondary/link-secondary--download.html
+++ b/rca/project_styleguide/templates/patterns/atoms/link-secondary/link-secondary--download.html
@@ -1,4 +1,4 @@
 <a class="link link--secondary link--download" href="{{ value.href }}">
-    <span class="link__label">{{ value.text }}</span>
+    <span class="link__label">{{ value.text }} ({{ value.file_extension|upper }} {{ value.get_file_size|filesizeformat }})</span>
     <svg width="12" height="8" class="link__icon" aria-hidden="true"><use xlink:href="#download"></use></svg>
 </a>

--- a/rca/project_styleguide/templates/patterns/atoms/link-tertiary/link-tertiary--download.html
+++ b/rca/project_styleguide/templates/patterns/atoms/link-tertiary/link-tertiary--download.html
@@ -1,4 +1,4 @@
 <a href="{{ value.href }}" class="link link--tertiary link--download">
-    <span class="link__label">{{ value.text }}</span>
+    <span class="link__label">{{ value.text }} ({{ value.file_extension|upper }} {{ value.get_file_size|filesizeformat }})</span>
     <svg width="12" height="8" class="link__icon" aria-hidden="true"><use xlink:href="#download"></use></svg>
 </a>

--- a/rca/project_styleguide/templates/patterns/molecules/key-details/key-details--project.html
+++ b/rca/project_styleguide/templates/patterns/molecules/key-details/key-details--project.html
@@ -70,10 +70,12 @@
     {% endif %}
     {% if page.specification_document %}
         <div class="key-details__section key-details__section--action">
-            <a class="key-details__link link link--primary link--download" href="{{ page.specification_document.url }}">
-                <span class="link__label">{{ page.specification_document_link_text|default:"Download project PDF" }}</span>
+            {% with file=page.specification_document %}
+            <a class="key-details__link link link--primary link--download" href="{{ file.url }}">
+                <span class="link__label">{{ page.specification_document_link_text|default:"Download project PDF" }} ({{ file.file_extension|upper }} {{ file.get_file_size|filesizeformat }})</span>
                 <svg width="8" height="12" class="link__icon" aria-hidden="true"><use xlink:href="#download"></use></svg>
             </a>
+            {% endwith %}
         </div>
     {% endif %}
 </div>

--- a/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.html
+++ b/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.html
@@ -136,10 +136,12 @@
         {% endif %}
         {% if page.programme_specification.url %}
             <div class="key-details__section key-details__section--action">
-                <a class="key-details__link link link--secondary link--download" href="{{ page.programme_specification.url }}">
-                    <span class="link__label">Download {{ page.programme_specification.title }}</span>
+                {% with file=page.programme_specification %}
+                <a class="key-details__link link link--secondary link--download" href="{{ file.url }}">
+                    <span class="link__label">Download {{ file.title }} ({{ file.file_extension|upper }} {{ file.get_file_size|filesizeformat }})</span>
                     <svg width="8" height="12" class="link__icon" aria-hidden="true"><use xlink:href="#download"></use></svg>
                 </a>
+                {% endwith %}
             </div>
         {% endif %}
         {% if social_media_links %}


### PR DESCRIPTION
Ticket: https://torchbox.monday.com/boards/1472452416/pulses/1472503836

This ticket covers adding both the file type and file size when displaying document uploads.

<img width="317" alt="Screenshot 2024-05-29 at 2 06 15 PM" src="https://github.com/torchbox/rca-wagtail-2019/assets/13232547/e048969f-53db-455b-b07a-19b48ff04981">
