### PR TITLE
Fix broken wagtailadmin user listing

### DIFF
--- a/rca/users/templates/wagtailusers/users/list.html
+++ b/rca/users/templates/wagtailusers/users/list.html
@@ -1,4 +1,4 @@
-{% load i18n wagtailusers_tags wagtailadmin_tags %}
+{% load i18n l10n wagtailusers_tags wagtailadmin_tags %}
 
 {# Override of https://github.com/wagtail/wagtail/blob/v6.0.2/wagtail/users/templates/wagtailusers/users/list.html to add custom columns #}
 
@@ -37,6 +37,8 @@
     <tbody>
         {% for user in users %}
             <tr>
+                {% fragment as title_id %}user_{{ user.pk|unlocalize|admin_urlquote }}_title{% endfragment %}
+                {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="user" instance=user aria_describedby=title_id only %}
                 <td class="title" valign="top">
                     <div class="title-wrapper">
                         {% avatar user=user size="small" %}


### PR DESCRIPTION
This is a small fix on the display of the overriden `wagtail/users/templates/wagtailusers/users/list.html` template. Please see the details below:

<details>
  <summary>Before</summary>

![Screenshot from 2024-06-16 21-13-47](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/e27f0c34-d78d-4207-8ee0-20dbcf0d4d87)


</details>

<details>
  <summary>After</summary>

![Screenshot from 2024-06-16 21-16-31](https://github.com/torchbox/rca-wagtail-2019/assets/7713776/c5e52b12-c34a-4879-8dd4-541ded596387)


</details>

> [!NOTE]
> It's worth noting that the `wagtail/users/templates/wagtailusers/users/list.html`  template is [removed in Wagtail 6.1](https://github.com/wagtail/wagtail/commit/7b1644eb37b6b6cf7800276acf9abef5254fc096). This is therefore a temporary fix before we upgrade to Wagtail 6.1