### PR TITLE
#3761 - Related page lists showing short courses

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/relatedcontent/relatedprogrammes.html
+++ b/rca/project_styleguide/templates/patterns/molecules/relatedcontent/relatedprogrammes.html
@@ -42,7 +42,7 @@
                             {% if related_item.degree_level %}
                                 <p class="related-content__degree body body--two" property="schema:EducationalCredentialAwarded">{{ related_item.degree_level }}</p>
                             {% elif related_item.programme_type %}
-                                <p class="related-content__degree body body--two">{{ related_item.programme_type }}</p>
+                                <p class="related-content__degree body body--two">{{ related_item.booking_summary|default:related_item.programme_type }}</p>
                             {% elif related_item.meta %}
                                 <p class="related-content__degree body body--two">{{ related_item.meta }}</p>
                             {% elif related_item.get_verbose_name == 'Guide page' %}

--- a/rca/shortcourses/models.py
+++ b/rca/shortcourses/models.py
@@ -413,3 +413,13 @@ class ShortCoursePage(ContactFieldsMixin, BasePage):
             "image"
         ).prefetch_related("page")
         return context
+
+    @property
+    def booking_summary(self):
+        booking_bar = self._format_booking_bar()
+
+        # If there's no date, the message would say "Bookings are not yet open"
+        if booking_date := booking_bar.get("date"):
+            return booking_date.strftime("%d %B %Y")
+
+        return booking_bar["message"]


### PR DESCRIPTION
[Ticket](https://torchbox.monday.com/boards/1472452416/pulses/1472503761)

> [!NOTE]  
> This change should only be applicable for **related short courses**

Example used:
`study/programme-finder/progression-portfolio-development/`

![image](https://github.com/torchbox/rca-wagtail-2019/assets/26372762/5e279c1a-b376-489a-a5ef-e9dea0952f68)
