### PR TITLE
Fix broken layout on short course pages

### DIFF
--- a/rca/project_styleguide/templates/patterns/pages/shortcourses/short_course.html
+++ b/rca/project_styleguide/templates/patterns/pages/shortcourses/short_course.html
@@ -21,7 +21,20 @@
             {% include "patterns/molecules/booking-bar/booking-bar.html" with item=booking_bar modal=booking_bar.modal modal_aria_label="booking-details-title" %}
         {% endif %}
 
-        <header class="page__header bg bg--dark{% if booking_bar %} page__header--with-sticky-cta{% endif %}">
+        {% comment %}
+        Text hits two lines when 'book now' is swapped out.
+        This modifier makes sure the layout doesn't break when
+        that's the case
+        {% endcomment %}
+        <header class="page__header bg bg--dark
+        {% if booking_bar %}
+            {% if booking_bar.action == 'Book now' %}
+                page__header--with-sticky-cta
+            {% else %}
+                page__header--with-sticky-cta-tall
+            {% endif %}
+        {% endif %}
+        ">
             <div class="title-area title-area--breadcrumb grid">
                 <div class="title-area__content">
                     <nav class="title-area__breadcrumb" aria-label="Breadcrumb">

--- a/rca/project_styleguide/templates/patterns/pages/shortcourses/short_course.html
+++ b/rca/project_styleguide/templates/patterns/pages/shortcourses/short_course.html
@@ -28,10 +28,10 @@
         {% endcomment %}
         <header class="page__header bg bg--dark
         {% if booking_bar %}
-            {% if booking_bar.action == 'Book now' %}
-                page__header--with-sticky-cta
-            {% else %}
+            {% if booking_bar.message == 'Bookings not yet open' %}
                 page__header--with-sticky-cta-tall
+            {% else %}
+                page__header--with-sticky-cta
             {% endif %}
         {% endif %}
         ">

--- a/rca/static_src/sass/components/_page.scss
+++ b/rca/static_src/sass/components/_page.scss
@@ -73,6 +73,14 @@
                 margin-top: -91px;
             }
         }
+
+        &--with-sticky-cta-tall {
+            margin-top: -75px;
+
+            @include media-query(medium) {
+                margin-top: -117px;
+            }
+        }
     }
 
     &__notch-block {
@@ -116,23 +124,6 @@
         &.bg--light {
             &::before {
                 background-color: $color--white;
-            }
-        }
-    }
-
-    .sticky-bar.app--short-course & {
-        #{$root}__header {
-            position: relative;
-
-            &::after {
-                content: '';
-                display: block;
-                position: absolute;
-                bottom: -91px;
-                left: 0;
-                background-color: $color--black;
-                width: 100%;
-                height: 91px; // height of booking bar
             }
         }
     }


### PR DESCRIPTION
The text within the booking bar often sits on one line. For example: https://www.rca.ac.uk/study/programme-finder/service-design-masterclass/

However, when the label is 'Register your interest for upcoming dates', it flows onto two lines. The page layout breaks when this happens, as heights/margins/etc assume the booking bar is shallower. For example, see the whitespace below the hero here: https://www.rca.ac.uk/study/programme-finder/human-centred-design-for-intelligent-mobility/

This PR aims to fix that. Creating a new modifier seemed like the easiest way, and we want to fix this asap since it's an issue on prod.