### PR TITLE
[3877] Non-anchor headings on guide page spacing

### DIFF
--- a/rca/static_src/sass/components/streamfield.scss
+++ b/rca/static_src/sass/components/streamfield.scss
@@ -38,4 +38,15 @@
             margin-bottom: ($gutter * 1.5);
         }
     }
+
+    .app--guide & {
+        // Match spacing of anchor headings on guide pages
+        &__heading {
+            padding-top: ($gutter * 3.5);
+
+            @include media-query(large) {
+                padding-top: ($gutter * 6);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Ticket: https://torchbox.monday.com/boards/1472452416/pulses/1472503877

There was no space above non-anchor headings on the guide pages so they looked odd in comparison to the anchor headings. This MR fixes that.

<details><summary>Before:</summary>
<p>

![Screenshot 2024-08-08 at 15 06 03](https://github.com/user-attachments/assets/1d0a862e-8359-4fba-97ec-696542260495)


</p>
</details> 



<details><summary>After:</summary>
<p>

![Screenshot 2024-08-08 at 15 06 09](https://github.com/user-attachments/assets/f02efaaa-085d-44c6-8b00-b1fabc9c1abb)



</p>
</details> 
