### PR TITLE
7446 - typed table block caption alignment and borders

### DIFF
--- a/rca/static_src/sass/components/_table.scss
+++ b/rca/static_src/sass/components/_table.scss
@@ -69,15 +69,9 @@
     caption {
         margin-bottom: $gutter;
         text-align: left;
-
-        @include media-query(medium) {
-            text-align: center;
-        }
     }
 
     table {
-        background: $color--white;
-        border: 1px solid $color--grid-line-dark;
         min-width: 600px;
         border-collapse: collapse;
 
@@ -87,7 +81,7 @@
 
         th,
         td {
-            padding: 8px;
+            padding: 8px 8px 8px 0;
         }
 
         th {


### PR DESCRIPTION
[Ticket](https://torchbox.monday.com/boards/1472452416/pulses/1538457446)

Missing commit for master - removing typed table block and left-aligning caption