### PR TITLE
[2601] Shorthand Embed FE

### DIFF
--- a/rca/project_styleguide/templates/patterns/pages/guide/guide.html
+++ b/rca/project_styleguide/templates/patterns/pages/guide/guide.html
@@ -3,7 +3,7 @@
 {% get_settings %}
 
 {% block body_class %}
-    app--guide no-hero sticky-bar
+    app--guide no-hero sticky-bar{% if page.shorthand_embed_code %} app--shorthand-embed{% endif %}
 {% endblock %}
 
 {% block tap_widget %}
@@ -119,7 +119,7 @@
             {% endif %}
         </div>
     </div>
-   
+
 
     {% if page.social_image %}
         {% image page.social_image fill-1200x1200 as social_img %}

--- a/rca/static_src/sass/abstracts/_variables.scss
+++ b/rca/static_src/sass/abstracts/_variables.scss
@@ -154,6 +154,7 @@ $z-index: (
     header-gridlines: 90,
     modal: 110,
     modal-controls: 120,
+    above-shorthand-embed: 210,
 );
 
 // --------------------------------- Grid Dimensions --------------------------------------

--- a/rca/static_src/sass/components/_app.scss
+++ b/rca/static_src/sass/components/_app.scss
@@ -103,4 +103,13 @@
         clip-path: inset(-0.5px 0 0 0);
         backface-visibility: hidden;
     }
+
+    // Make sure the header and navigation are above the shorthand embed
+    // which has a 3rd party z-index of 200
+    &--shorthand-embed {
+        #{$root}__navigation,
+        #{$root}__header {
+            @include z-index(above-shorthand-embed);
+        }
+    }
 }

--- a/rca/static_src/sass/components/_grid.scss
+++ b/rca/static_src/sass/components/_grid.scss
@@ -135,4 +135,11 @@
             }
         }
     }
+
+    // Hide the grid lines on the guide page when a shorthand embed is present
+    .app--shorthand-embed & {
+        &__lines {
+            display: none;
+        }
+    }
 }


### PR DESCRIPTION
Ticket: https://torchbox.monday.com/boards/1472452416/pulses/1538412601

FE fixes for the shorthand embed that can be added to a guide page:

- Add a body class to the guide page when a shorthand embed has been added to the page
- Hide the grid lines on the guide page when the embed is on the page
- Make sure the header, search and nav appear on top of the embed