### PR TITLE
#4730 - BUG | Guide Page > Related Staff module (desktop)

### DIFF
--- a/rca/static_src/sass/components/_carousel.scss
+++ b/rca/static_src/sass/components/_carousel.scss
@@ -231,6 +231,8 @@
         display: none;
 
         @include media-query(large) {
+            @include z-index(modal-controls);
+
             display: block;
         }
     }


### PR DESCRIPTION
Ticket: https://torchbox.monday.com/boards/1472452416/pulses/1617104730

This MR fixes an issue where the arrows buttons for a carousel might sometimes be unclickable. It's because they're hidden behind another element.

![Screenshot 2024-09-20 at 9 41 16 AM](https://github.com/user-attachments/assets/54f0876a-fe04-4c5a-bb40-4e148db878d3)
