### PR TITLE
#7888 - BUG | Home 'Hero CTA sub text'

### DIFF
--- a/rca/static_src/sass/components/_hero-action-pane.scss
+++ b/rca/static_src/sass/components/_hero-action-pane.scss
@@ -1,6 +1,6 @@
 .hero-action-pane {
     $root: &;
-    $hero-action-pane-height-small: 110px;
+    $hero-action-pane-height-small: 190px;
     $hero-action-pane-height-medium: 160px;
     $hero-image-credit-height: 40px;
     $hero-action-pane-overlap: 80px;


### PR DESCRIPTION
Ticket: https://torchbox.monday.com/boards/1472452416/pulses/1630887888

This PR fixes an issue where the hero CTA sub text is cut off on mobile.

Screenshot:

<img width="424" alt="Screenshot 2024-09-20 at 3 06 50 PM" src="https://github.com/user-attachments/assets/7285b824-b09a-40dc-bf31-5860159547c1">
