### PR TITLE
#7265 - Accessibility | ADR_21184-5 Anchor tags with no href do not receive keyboard focus

### DIFF
--- a/rca/project_styleguide/templates/patterns/atoms/back-link/back-link.html
+++ b/rca/project_styleguide/templates/patterns/atoms/back-link/back-link.html
@@ -1,4 +1,4 @@
-<a class="back-link" data-subnav-back>
+<button class="button back-link" data-subnav-back>
     <svg class="back-link__icon" width="12" height="8" aria-hidden="true"><use xlink:href="#arrow"></use></svg>
     <span class="back-link__text">Back</span>
-</a>
+</button>

--- a/rca/project_styleguide/templates/patterns/molecules/video-modal/video-modal.html
+++ b/rca/project_styleguide/templates/patterns/molecules/video-modal/video-modal.html
@@ -4,9 +4,9 @@
         <a data-modal-open>Open video</a>
     {% endif %}
     <div data-modal-window class="video-modal" aria-live="polite">
-        <a data-modal-close class="video-modal__close">
+        <button data-modal-close class="button video-modal__close">
             <svg class="video-modal__close-icon" width="20" height="20"><use xlink:href="#close"></use></svg>
-        </a>
+        </button>
         <div class="video-modal__container">
             <div style="padding-bottom: 56.25%" class="responsive-object">
                 {% embed video %}

--- a/rca/static_src/sass/components/_back-link.scss
+++ b/rca/static_src/sass/components/_back-link.scss
@@ -8,6 +8,10 @@
     display: flex;
     pointer-events: none;
 
+    &:focus {
+        outline: 2px solid $color--focus;
+    }
+
     @include media-query(medium) {
         margin-top: ($gutter * 3.25);
     }
@@ -31,7 +35,7 @@
             }
         }
 
-        &:hover {
+        &:hover, &:focus {
             span {
                 &::after {
                     width: 100%;

--- a/rca/static_src/sass/components/_video-modal.scss
+++ b/rca/static_src/sass/components/_video-modal.scss
@@ -43,6 +43,10 @@
         top: 20px;
         right: 20px;
 
+        &:focus {
+            outline: 2px solid $color--focus;
+        }
+
         .is-open & {
             pointer-events: all;
         }


### PR DESCRIPTION
Ticket: https://torchbox.monday.com/boards/1472452416/pulses/1663117265

This PR makes some accessibility fixes to some elements in the build:

- In the navigation, 'Back' is set to as a link which is not focusable. We update this to be a button.
- When opening a video embed, the close button is not focusable as well. We update this to be a button.

In the ticket/document, there's a link in https://www.rca.ac.uk/study/programme-finder/art-design-graduate-diploma/ which is not focusable -- specifically the one with the text "Next on-campus open day: 16 October 2024". This is caused by a broken link so that just needs to be updated editorially.