### PR TITLE
#0965 - PROGRAMME PAGES - KEY DETAILS | Change field label 'Location' to 'Current Location'

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.html
+++ b/rca/project_styleguide/templates/patterns/molecules/key-details/key-details.html
@@ -83,7 +83,7 @@
         {% endif %}
         {% if page.campus_locations %}
             <div class="key-details__section key-details__section--school">
-                <h5 class="body body--two key-details__sub-heading">Location</h5>
+                <h5 class="body body--two key-details__sub-heading">Current location</h5>
                 <ul class="key-details__list">
                     {% for location in page.campus_locations %}
                     <li class="key-details__list-item">


### PR DESCRIPTION
This ticket covers updating the label of the key details in program pages to be "Current location" instead of just "Location".

Ticket: https://torchbox.monday.com/boards/1472452416/pulses/1745180965

No BE changes for this.