### PR TITLE
#5931 - Listing order of research projects

### DIFF
--- a/rca/projects/models.py
+++ b/rca/projects/models.py
@@ -485,7 +485,14 @@ class ProjectPickerPage(BasePage):
         return projects_formatted
 
     def get_base_queryset(self):
-        return ProjectPage.objects.child_of(self).live().order_by("title")
+        # Projects with an empty `end_date` shows first.
+        # This is followed by projects with an end date, with most recent date first.
+        # If two projects have the same end date, it's based on the last published date.
+        return (
+            ProjectPage.objects.child_of(self)
+            .live()
+            .order_by(models.F("end_date").desc(nulls_first=True), "-last_published_at")
+        )
 
     def modify_results(self, paginator_page, request):
         for obj in paginator_page.object_list:


### PR DESCRIPTION
Ticket: https://torchbox.monday.com/boards/1472452416/pulses/1667565931

This MR updates the listing order of research projects. It used to be that its only sorted by title. We want to use the end date instead.