### PR TITLE
#9177 - FE | Home hero text component refactor

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/hero-action-pane/hero-action-pane.html
+++ b/rca/project_styleguide/templates/patterns/molecules/hero-action-pane/hero-action-pane.html
@@ -1,23 +1,8 @@
 {% load wagtailcore_tags navigation_tags %}
 
-
 <div class="hero-action-pane grid">
-
-    <button class="hero-action-pane__credit" aria-label="Show image credit" data-parallax data-rellax-speed="-1" x-data="{ open: !false }"
-    class="data-viewer__toggle" x-on:click="open = ! open" x-bind:class="! open ? 'hero-action-pane__credit--open' : ''">
-        <svg class="hero-action-pane__credit-icon hero-action-pane__credit-icon--open" width="24" height="24" aria-hidden="true">
-            <use xlink:href="#camera" />
-        </svg>
-        <svg class="hero-action-pane__credit-icon hero-action-pane__credit-icon--close" width="24" height="24" aria-hidden="true">
-            <use xlink:href="#close" />
-        </svg>
-        <div class="hero-action-pane__credit-details">
-            {% include 'patterns/atoms/image-info/image-info.html' with credit=page.hero_image_credit item=page.hero_image %}
-        </div>
-    </button>
-
     {% if page.hero_cta_url %}
-        <div class="hero-action-pane__cta" data-parallax data-rellax-speed="-3">
+        <div class="hero-action-pane__cta" data-parallax data-rellax-speed="-1">
             <a href="{{ page.hero_cta_url }}" class="hero-action-pane__cta-link">
                 <div class="hero-action-pane__cta-heading">
                     {{ page.hero_cta_text }}
@@ -31,7 +16,20 @@
             </a>
         </div>
     {% endif %}
+    
     <div class="hero-action-pane__links" data-parallax data-rellax-speed="-1">
+        <button class="hero-action-pane__credit" aria-label="Show image credit" x-data="{ open: !false }"
+        class="data-viewer__toggle" x-on:click="open = ! open" x-bind:class="! open ? 'hero-action-pane__credit--open' : ''">
+            <svg class="hero-action-pane__credit-icon hero-action-pane__credit-icon--open" width="24" height="24" aria-hidden="true">
+                <use xlink:href="#camera" />
+            </svg>
+            <svg class="hero-action-pane__credit-icon hero-action-pane__credit-icon--close" width="24" height="24" aria-hidden="true">
+                <use xlink:href="#close" />
+            </svg>
+            <div class="hero-action-pane__credit-details">
+                {% include 'patterns/atoms/image-info/image-info.html' with credit=page.hero_image_credit item=page.hero_image %}
+            </div>
+        </button>
 
         {% audience_links as links %}
         {% for value in links %}

--- a/rca/project_styleguide/templates/patterns/pages/home/home_page.html
+++ b/rca/project_styleguide/templates/patterns/pages/home/home_page.html
@@ -15,12 +15,13 @@
 
     {% include "patterns/molecules/hero/hero--home.html" with modifier="home" scrolldown=true %}
 
+    {% include "patterns/molecules/hero-action-pane/hero-action-pane.html" %}
+    
     <div class="page page--overlay" id="content">
 
         <span id="main-content"></span>
 
         {% include "patterns/atoms/grid-lines/grid-lines.html" %}
-        {% include "patterns/molecules/hero-action-pane/hero-action-pane.html" %}
 
         <div class="page__content">
 

--- a/rca/static_src/sass/components/_hero-action-pane.scss
+++ b/rca/static_src/sass/components/_hero-action-pane.scss
@@ -1,32 +1,16 @@
 .hero-action-pane {
     $root: &;
-    $hero-action-pane-height-small: 190px;
-    $hero-action-pane-height-medium: 160px;
-    $hero-image-credit-height: 40px;
     $hero-action-pane-overlap: 80px;
-    $hero-action-pane-height-large: (
-        $hero-action-pane-height-medium + $hero-image-credit-height
-    );
-    @include z-index(under);
+    @include z-index(under-gridlines);
     position: relative;
     pointer-events: none;
-    height: $hero-action-pane-height-small;
-    top: -$hero-action-pane-height-small;
-    margin-bottom: -$hero-action-pane-height-small;
-    overflow: hidden;
 
     @include media-query(medium) {
-        height: $hero-action-pane-height-medium;
-        top: -$hero-action-pane-height-medium;
-        margin-bottom: -$hero-action-pane-height-medium;
         pointer-events: auto;
     }
 
     @include media-query(large) {
-        padding-top: $hero-image-credit-height;
-        height: $hero-action-pane-height-large;
-        top: -$hero-action-pane-height-large;
-        margin-bottom: -$hero-action-pane-height-large;
+        margin-top: -150px;
     }
 
     &__links {
@@ -39,7 +23,7 @@
         @include media-query(large) {
             @include z-index(sticky-nav-bar);
             display: grid;
-            max-height: $hero-action-pane-height-medium;
+            align-self: flex-end;
             grid-template-columns: 1fr 1fr 27.5%;
         }
 
@@ -48,7 +32,7 @@
             position: absolute;
             display: block;
             width: ($gutter * 4);
-            height: $hero-action-pane-height-medium;
+            height: 100%;
             transform: translate3d(-$hero-action-pane-overlap, 0, 0);
             background-color: $color--white;
         }
@@ -57,8 +41,9 @@
             content: '';
             position: absolute;
             display: block;
-            width: 100%;
-            height: $hero-action-pane-height-medium;
+            width: ($gutter * 4);
+            right: 0;
+            height: 100%;
             transform: translate3d(
                 99%,
                 0,
@@ -71,10 +56,11 @@
     &__cta {
         grid-column: 1;
         padding-bottom: ($gutter * 1.75);
+        position: absolute;
+        bottom: 0;
 
         @include media-query(large) {
-            padding-bottom: 0;
-            padding-top: ($gutter);
+            padding: ($gutter) 0;
         }
 
         // Custom breakpoint to target mobile only to prevent rellax doing its thing
@@ -166,16 +152,15 @@
         @include media-query(large) {
             @include z-index(above-gridlines);
             position: absolute;
-            top: 0;
+            top: -40px;
             width: 40px;
-            left: -$hero-action-pane-overlap; // align with white block below
-            height: $hero-image-credit-height;
+            left: -($gutter * 4);
+            height: 40px;
             display: flex;
             flex-direction: row;
             align-items: center;
             justify-content: flex-start;
             background-color: $color--black;
-            grid-column: 3 / span 3;
             border: 0;
             padding: 0;
             margin: 0;

--- a/rca/static_src/sass/components/_hero-action-pane.scss
+++ b/rca/static_src/sass/components/_hero-action-pane.scss
@@ -9,7 +9,13 @@
         pointer-events: auto;
     }
 
-    @include media-query(large) {
+    // Between 1024px and 1122px
+    @media only screen and (min-width: 1024px) and (max-width: 1122px) {
+        margin-top: -190px;
+    }
+
+    // Over 1122px
+    @media only screen and (min-width: 1122px) {
         margin-top: -150px;
     }
 
@@ -20,7 +26,7 @@
         background-color: $color--white;
         padding: ($gutter * 2) 0;
 
-        @include media-query(large) {
+        @media only screen and (min-width: 1024px) {
             @include z-index(sticky-nav-bar);
             display: grid;
             align-self: flex-end;

--- a/rca/static_src/sass/components/_hero-action-pane.scss
+++ b/rca/static_src/sass/components/_hero-action-pane.scss
@@ -4,6 +4,7 @@
     @include z-index(under-gridlines);
     position: relative;
     pointer-events: none;
+    overflow-x: clip;
 
     @include media-query(medium) {
         pointer-events: auto;
@@ -11,7 +12,7 @@
 
     // Between 1024px and 1122px
     @media only screen and (min-width: 1024px) and (max-width: 1122px) {
-        margin-top: -190px;
+        margin-top: -200px;
     }
 
     // Over 1122px


### PR DESCRIPTION
Ticket: https://torchbox.monday.com/boards/1472452416/pulses/1636969177

This PR refactors the CTA section in the hero home page. The gist of the changes are:

- Move the hero action pane away from the main content area to below the hero image.
- On desktop, pull the hero action pane up.

<img width="1912" alt="Screenshot 2025-01-14 at 1 04 27 PM" src="https://github.com/user-attachments/assets/63610bb5-3e1c-44f7-a1ee-6f660a98013e" />
