### PR TITLE
Stop pulling news & events from the defunct legacy site

### DIFF
--- a/rca/utils/models.py
+++ b/rca/utils/models.py
@@ -26,7 +26,7 @@ from wagtail.models import Orderable, Page
 from wagtail.search import index
 from wagtail.snippets.models import register_snippet
 
-from rca.api_content.content import CantPullFromRcaApi, pull_tagged_news_and_events
+from rca.api_content.content import CantPullFromRcaApi
 from rca.utils.cache import get_default_cache_control_decorator
 from rca.utils.forms import RCAPageAdminForm
 
@@ -655,14 +655,14 @@ class LegacyNewsAndEventsMixin(models.Model):
 
     def refetch_legacy_news_and_events(self):
         """
-        Fetches the related news and events for this page from
-        the legacy site. The result is cached to reduce real-time
-        calls to the legacy API.
+        Method which used to fetch related news and events from
+        the legacy site. This site is now defunct, so this method
+        is no longer expected to return anything.
+
+        TODO: remove this and other references in the codebase to
+              it or to the legacy news and events content
         """
-        tags = self.legacy_news_and_event_tags.all().values_list("name", flat=True)
-        value = pull_tagged_news_and_events(*tags)
-        cache.set(self.legacy_news_cache_key, value, None)
-        return value
+        return []
 
     @cached_property
     def legacy_news_and_events(self):


### PR DESCRIPTION
As the legacy site is no longer online, calls to its content from the `refetch_legacy_news_and_events` fail, causing errors on pages whose templates render the legacy content. This fixes those errors by making `refetch_legacy_news_and_events` return an empty list instead, which will get things working until a longer-term code cleanup can take place.