### PR TITLE
#1007 - SCHOOLS  PAGES - KEY DETAILS | Change field label 'Location' to 'Current Location'

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/key-details/key-details--schools.html
+++ b/rca/project_styleguide/templates/patterns/molecules/key-details/key-details--schools.html
@@ -19,7 +19,7 @@
 
     {% if page.location %}
     <div class="key-details__section key-details__section--location">
-        <h3 class="body body--two key-details__sub-heading">Location</h3>
+        <h3 class="body body--two key-details__sub-heading">Current Location</h3>
         <ul class="key-details__list">
             <li class="key-details__list-item key-details__list-item--tight">
                 {{ page.location|richtext }}

--- a/rca/schools/models.py
+++ b/rca/schools/models.py
@@ -337,7 +337,7 @@ class SchoolPage(ContactFieldsMixin, LegacyNewsAndEventsMixin, BasePage):
             [FieldPanel("next_open_day_date"), FieldPanel("link_to_open_days")],
             heading="Next open day",
         ),
-        FieldPanel("location"),
+        FieldPanel("location", heading="Current location"),
         FieldPanel("get_in_touch"),
         FieldPanel("social_links"),
     ]


### PR DESCRIPTION
Ticket: https://torchbox.monday.com/boards/1472452416/pulses/1811011007

This PR updates the hard coded 'Location' label on school pages.

![Screenshot 2025-04-21 at 2 09 41 PM](https://github.com/user-attachments/assets/e59a12c0-ac79-4b7c-bf00-73b7070a6322)
