### PR TITLE
#2535 - FE | Home page - Featured Alumni stories logic

### DIFF
--- a/rca/home/models.py
+++ b/rca/home/models.py
@@ -390,12 +390,15 @@ class HomePage(TapMixin, BasePage):
         return [
             self.related_news_events_formatter(
                 item.story,
-                editorial_meta_label="Alumni story",
+                editorial_meta_label=item.story.listing_meta,
                 long_description=True,
             )
             for item in self.featured_alumni_stories.filter(story__live=True)
             .select_related("story", "story__listing_image")
-            .prefetch_related("story__listing_image__renditions")
+            .prefetch_related(
+                "story__listing_image__renditions",
+                "story__editorial_types__type",
+            )
         ]
 
     def get_context(self, request, *args, **kwargs):

--- a/rca/home/models.py
+++ b/rca/home/models.py
@@ -390,7 +390,7 @@ class HomePage(TapMixin, BasePage):
         return [
             self.related_news_events_formatter(
                 item.story,
-                editorial_meta_label=item.story.listing_meta,
+                editorial_meta_label=item.story.listing_meta or "Alumni stories",
                 long_description=True,
             )
             for item in self.featured_alumni_stories.filter(story__live=True)

--- a/rca/home/models.py
+++ b/rca/home/models.py
@@ -390,7 +390,7 @@ class HomePage(TapMixin, BasePage):
         return [
             self.related_news_events_formatter(
                 item.story,
-                editorial_meta_label=item.story.listing_meta or "Alumni stories",
+                editorial_meta_label=item.story.listing_meta or "Alumni story",
                 long_description=True,
             )
             for item in self.featured_alumni_stories.filter(story__live=True)


### PR DESCRIPTION
Ticket: https://torchbox.monday.com/boards/1472452416/pulses/1808782535

This PR updates the meta label in featured alumni section in the home page to use the types of the editorial page. Currently, it's all hard coded to "Alumni stories".