### PR TITLE
#6855 - BUSINESS | Case Studies Listing order

### DIFF
--- a/rca/projects/models.py
+++ b/rca/projects/models.py
@@ -485,13 +485,10 @@ class ProjectPickerPage(BasePage):
         return projects_formatted
 
     def get_base_queryset(self):
-        # Projects with an empty `end_date` shows first.
-        # This is followed by projects with an end date, with most recent date first.
-        # If two projects have the same end date, it's based on the last published date.
         return (
             ProjectPage.objects.child_of(self)
             .live()
-            .order_by(models.F("end_date").desc(nulls_first=True), "-last_published_at")
+            .order_by("-first_published_at")
         )
 
     def modify_results(self, paginator_page, request):

--- a/rca/projects/models.py
+++ b/rca/projects/models.py
@@ -485,11 +485,7 @@ class ProjectPickerPage(BasePage):
         return projects_formatted
 
     def get_base_queryset(self):
-        return (
-            ProjectPage.objects.child_of(self)
-            .live()
-            .order_by("-first_published_at")
-        )
+        return ProjectPage.objects.child_of(self).live().order_by("-first_published_at")
 
     def modify_results(self, paginator_page, request):
         for obj in paginator_page.object_list:


### PR DESCRIPTION
Ticket: https://torchbox.monday.com/boards/1472452416/pulses/1811016855

This PR updates the ordering of projects in the project picker page. Previously, it's based on end date with the ones with no end date being first. Instead, it'll just be based on when it was first published (so newer ones are surfaced).