### PR TITLE
Fix search listings for promoted items with external links

### DIFF
--- a/rca/project_styleguide/templates/patterns/molecules/search-result/search-result.html
+++ b/rca/project_styleguide/templates/patterns/molecules/search-result/search-result.html
@@ -1,9 +1,13 @@
 {% load static wagtailcore_tags wagtailsearchpromotions_tags wagtailimages_tags %}
 
 <div class="search-result">
+{% if pick.external_link_url %}
+    <a class="search-result__link grid" href="{{ pick.external_link_url }}">
+{% else %}
     <a class="search-result__link grid" href="{% pageurl result %}">
+{% endif %}
         <div class="search-result__header layout__@large-start-two layout__@large-span-one">
-            <h3 class="search-result__heading heading heading--five">{% firstof result.listing_title result.title %}</h3>
+            <h3 class="search-result__heading heading heading--five">{% firstof pick.external_link_text result.listing_title result.title %}</h3>
             {% if search_pick %}<div class="search-result__editor-pick body body--support">Recommended result</div>{% endif %}
         </div>
         {% with meta=result.specific.listing_meta %}


### PR DESCRIPTION
Fix for [incident reported 2025-05-12, 15:27](https://torchbox.monday.com/boards/1124499850/pulses/1954183790)

The template for _search.html_ passes promoted search items to _search-result.html_, with the assumption that there will be a `page` item attached which can be used to output the item in the results listing. This isn't true in the case of promoted items using external links, causing a template error, so this PR adds code to handle external promoted items.