### PR TITLE
R1-224: PROGRAMME PAGE | Video display

### DIFF
--- a/rca/project_styleguide/templates/patterns/organisms/image-video-block/image-video-block.html
+++ b/rca/project_styleguide/templates/patterns/organisms/image-video-block/image-video-block.html
@@ -1,4 +1,3 @@
-
 <div class="image-video-block {% if modifier %}image-video-block--{{ modifier }}{% endif %}">
     {% if heading or has_meta or curriculum %}
         <div class="section__row grid">

--- a/rca/project_styleguide/templates/patterns/organisms/image-video-embed/image-video-embed.html
+++ b/rca/project_styleguide/templates/patterns/organisms/image-video-embed/image-video-embed.html
@@ -3,22 +3,27 @@
 
 <div class="image-video-embed">
     <div class="image-video-embed__container" {% if modal and video %}data-video-modal{% endif %}>
-        <a data-modal-open class="image-video-embed__link" aria-label="Play {{ caption }}" tabindex="0">
-            {% if image %}
-                {% image image fill-80x37 as image_small %}
-                {% image image fill-900x415 as image_large %}
+        {% image image fill-80x37 as image_small %}
+        {% image image fill-900x415 as image_large %}
+
+        {% if video %}
+            <a data-modal-open class="image-video-embed__link" aria-label="Play {{ caption }}" tabindex="0">
 
                 {% include "patterns/atoms/image/image--lazyload.html" with image_small=image_small width=900 height=415 image_large=image_large classList='image-video-embed__image' %}
-            {% endif %}
-        
-            <svg class="image-video-embed__play-icon" aria-hidden="true" width="87" height="87" viewBox="0 0 90 85">
-                <path d="M43.5 0C19.575 0 0 19.575 0 43.5C0 67.425 19.575 87 43.5 87C67.425 87 87 67.425 87 43.5C87 19.575 67.425 0 43.5 0ZM34.8 63.075V23.925L60.9 43.5L34.8 63.075Z" fill="white"/>
-                <path d="M34.8 23.925V63.075L60.9 43.5L34.8 23.925Z" fill="#FF5D1C"/>
-            </svg>
+            
+                <svg class="image-video-embed__play-icon" aria-hidden="true" width="87" height="87" viewBox="0 0 90 85">
+                    <path d="M43.5 0C19.575 0 0 19.575 0 43.5C0 67.425 19.575 87 43.5 87C67.425 87 87 67.425 87 43.5C87 19.575 67.425 0 43.5 0ZM34.8 63.075V23.925L60.9 43.5L34.8 63.075Z" fill="white"/>
+                    <path d="M34.8 23.925V63.075L60.9 43.5L34.8 23.925Z" fill="#FF5D1C"/>
+                </svg>
+            
+                {% if caption %}
+                    <p class="image-video-embed__caption">{{ caption }}</p>
+                {% endif %}
+            </a>
 
-            <p class="image-video-embed__caption">{{ caption }}</p>
-        </a>
-
-        {% include "patterns/molecules/video-modal/video-modal.html" with open_link=False %}
+            {% include "patterns/molecules/video-modal/video-modal.html" with open_link=False %}
+        {% else %}
+            {% include "patterns/atoms/image/image--lazyload.html" with image_small=image_small width=900 height=415 image_large=image_large classList='image-video-embed__image' %}
+        {% endif %}
     </div>
 </div>

--- a/rca/project_styleguide/templates/patterns/organisms/image-video-embed/image-video-embed.html
+++ b/rca/project_styleguide/templates/patterns/organisms/image-video-embed/image-video-embed.html
@@ -1,4 +1,4 @@
-
+{# This is similar to image-video-block. Key difference is that the play button is centered and the caption is below the image. #}
 {% load wagtailcore_tags wagtailimages_tags %}
 
 <div class="image-video-embed">

--- a/rca/project_styleguide/templates/patterns/organisms/image-video-embed/image-video-embed.html
+++ b/rca/project_styleguide/templates/patterns/organisms/image-video-embed/image-video-embed.html
@@ -1,0 +1,24 @@
+
+{% load wagtailcore_tags wagtailimages_tags %}
+
+<div class="image-video-embed">
+    <div class="image-video-embed__container" {% if modal and video %}data-video-modal{% endif %}>
+        <a data-modal-open class="image-video-embed__link" aria-label="Play {{ caption }}" tabindex="0">
+            {% if image %}
+                {% image image fill-80x37 as image_small %}
+                {% image image fill-900x415 as image_large %}
+
+                {% include "patterns/atoms/image/image--lazyload.html" with image_small=image_small width=900 height=415 image_large=image_large classList='image-video-embed__image' %}
+            {% endif %}
+        
+            <svg class="image-video-embed__play-icon" aria-hidden="true" width="87" height="87" viewBox="0 0 90 85">
+                <path d="M43.5 0C19.575 0 0 19.575 0 43.5C0 67.425 19.575 87 43.5 87C67.425 87 87 67.425 87 43.5C87 19.575 67.425 0 43.5 0ZM34.8 63.075V23.925L60.9 43.5L34.8 63.075Z" fill="white"/>
+                <path d="M34.8 23.925V63.075L60.9 43.5L34.8 23.925Z" fill="#FF5D1C"/>
+            </svg>
+
+            <p class="image-video-embed__caption">{{ caption }}</p>
+        </a>
+
+        {% include "patterns/molecules/video-modal/video-modal.html" with open_link=False %}
+    </div>
+</div>

--- a/rca/project_styleguide/templates/patterns/organisms/image-video-embed/image-video-embed.yaml
+++ b/rca/project_styleguide/templates/patterns/organisms/image-video-embed/image-video-embed.yaml
@@ -1,0 +1,16 @@
+context:
+  caption: Watch inside our architecture studios
+  video: True
+
+tags:
+  image:
+    image fill-80x37 as image_small:
+      target_var: image_small
+      raw:
+        url: '//placekitten.com/80/37'
+    image fill-900x415 as image_large:
+      target_var: image_large
+      raw:
+        url: '//placekitten.com/900/415'
+        width: '900'
+        height: '415'

--- a/rca/project_styleguide/templates/patterns/organisms/programme_tabs/programme_overview.html
+++ b/rca/project_styleguide/templates/patterns/organisms/programme_tabs/programme_overview.html
@@ -16,7 +16,7 @@
                     <h4 class="introduction introduction--end heading heading--five" property="schema:description">{{ page.programme_description_subtitle }}</h4>
                 {% endif %}
                 {% if page.programme_image %}
-                    {% include "patterns/organisms/image-video-block/image-video-block.html" with modal=page.programme_video image=page.programme_image caption=page.programme_video_caption video=page.programme_video out_of_grid="true" heading=false has_meta=false subheading=false copy=false %}
+                    {% include "patterns/organisms/image-video-embed/image-video-embed.html" with modal=page.programme_video image=page.programme_image caption=page.programme_video_caption video=page.programme_video out_of_grid="true" heading=false has_meta=false subheading=false copy=false %}
                 {% endif %}
                 <div class="programme-overview__description rich-text">
                     {{ page.programme_description_copy|safe }}

--- a/rca/static_src/sass/components/_image-video-embed.scss
+++ b/rca/static_src/sass/components/_image-video-embed.scss
@@ -1,0 +1,87 @@
+.image-video-embed {
+    $root: &;
+    margin-bottom: ($gutter * 2);
+
+    @include media-query(medium) {
+        margin-bottom: ($gutter * 3);
+    }
+
+    @include media-query(large) {
+        margin-bottom: ($gutter * 4);
+    }
+
+    &__container {
+        grid-column: 1 / span 2;
+
+        @include media-query(large) {
+            grid-column: 2 / span 3;
+        }
+    }
+
+    &__image {
+        @include z-index(above-gridlines);
+        position: relative;
+
+        #{$root}__link & {
+            opacity: 0.8;
+
+            @include media-query(medium) {
+                opacity: 1;
+                transition: opacity $transition;
+
+                #{$root}:hover & {
+                    opacity: 0.8;
+                }
+            }
+        }
+    }
+
+    &__link {
+        display: block;
+        position: relative;
+
+        &:active,
+        &:focus,
+        &:hover {
+            cursor: pointer;
+
+            #{$root}__caption {
+                color: $color--orange;
+            }
+
+            #{$root}__play-icon {
+                path:nth-child(2) {
+                    fill-opacity: 1;
+                }
+            }
+        }
+    }
+
+    &__play-icon {
+        @include z-index(above-gridlines);
+        position: absolute;
+        left: 50%;
+        top: 40%;
+        transform: translate3d(-50%, -50%, 0);
+        pointer-events: none;
+        height: 50px;
+        width: 50px;
+
+        path:nth-child(2) {
+            fill-opacity: 0;
+        }
+
+        @include media-query(medium) {
+            height: 80px;
+            top: 45%;
+            width: 80px;
+        }
+    }
+
+    &__caption {
+        display: block;
+        margin-top: $gutter;
+        text-decoration: underline;
+    }
+}
+

--- a/rca/static_src/sass/components/_image-video-embed.scss
+++ b/rca/static_src/sass/components/_image-video-embed.scss
@@ -84,4 +84,3 @@
         text-decoration: underline;
     }
 }
-

--- a/rca/static_src/sass/components/_image-video-embed.scss
+++ b/rca/static_src/sass/components/_image-video-embed.scss
@@ -6,10 +6,6 @@
         margin-bottom: ($gutter * 3);
     }
 
-    @include media-query(large) {
-        margin-bottom: ($gutter * 4);
-    }
-
     &__container {
         grid-column: 1 / span 2;
 

--- a/rca/static_src/sass/main.scss
+++ b/rca/static_src/sass/main.scss
@@ -39,6 +39,7 @@
 @import 'components/contact-anchor';
 @import 'components/cluetip';
 @import 'components/image-video-block';
+@import 'components/image-video-embed';
 @import 'components/disclaimer';
 @import 'components/donate-form';
 @import 'components/embed';


### PR DESCRIPTION
This PR restyles the video embed in programme pages. All other pages/areas where a video embed exists are untouched.

Ticket: https://torchbox.atlassian.net/browse/R1-224

<details><summary>Screenshots</summary>
<p>

Default:
<img width="736" height="468" alt="Screenshot 2025-07-17 at 6 35 59 PM" src="https://github.com/user-attachments/assets/48979adb-7d47-4445-a14d-56c6e5ee1719" />

On hover:
<img width="884" height="463" alt="Screenshot 2025-07-17 at 6 35 56 PM" src="https://github.com/user-attachments/assets/88735887-0af7-4083-a78d-067f9b1e8bba" />

</p>
</details> 