### PR TITLE
R1-174: BUG | SEO - Event page structured data error

### DIFF
--- a/rca/project_styleguide/templates/patterns/pages/events/event_detail--limited.yaml
+++ b/rca/project_styleguide/templates/patterns/pages/events/event_detail--limited.yaml
@@ -12,8 +12,8 @@ context:
         title: Events
     introduction: '<p>Situated within the Royal College of Art, a world-leading art and design institution, the programme encourages interdisciplinary and cross-disciplinary research projects in…</p>'
     event_date: '13 December 2020'
-    event_startDate: !!timestamp '2020-12-13 2:00:00+01:00'
-    event_endDate: !!timestamp '2020-12-16 2:00:00+01:00'
+    start_date: !!timestamp '2020-12-13 2:00:00+01:00'
+    end_date: !!timestamp '2020-12-16 2:00:00+01:00'
     event_time: 5pm – 8pm
     timezone: GMT +1
     location: Online

--- a/rca/project_styleguide/templates/patterns/pages/events/event_detail.html
+++ b/rca/project_styleguide/templates/patterns/pages/events/event_detail.html
@@ -169,8 +169,8 @@
           "@context": "https://schema.org",
           "@type": "Event",
           "name": "{{ page.title }}",
-          "startDate": "{{ page.event_startDate|date:'c' }}",
-          "endDate": "{{ page.event_endDate|date:'c' }}",
+          "startDate": "{{ page.start_date|date:'c' }}",
+          "endDate": "{{ page.end_date|date:'c' }}",
           "eventStatus": "https://schema.org/EventScheduled",
           "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
           "location": {

--- a/rca/project_styleguide/templates/patterns/pages/events/event_detail.yaml
+++ b/rca/project_styleguide/templates/patterns/pages/events/event_detail.yaml
@@ -12,8 +12,8 @@ context:
         title: Events
     introduction: '<p>Situated within the Royal College of Art, a world-leading art and design institution, the programme encourages interdisciplinary and cross-disciplinary research projects in…</p>'
     event_date: '13 December 2020'
-    event_startDate: !!timestamp '2020-12-13 2:00:00+01:00'
-    event_endDate: !!timestamp '2020-12-16 2:00:00+01:00'
+    start_date: !!timestamp '2020-12-13 2:00:00+01:00'
+    end_date: !!timestamp '2020-12-16 2:00:00+01:00'
     event_time: 5pm – 8pm
     timezone: GMT +1
     location: Online


### PR DESCRIPTION
This pull request fixes an issue where the wrong variable names are for the ld+json schema in event pages.

Ticket: https://torchbox.atlassian.net/browse/R1-174

<details><summary>Before and after</summary>
<p>

Before:
```

        {
          "@context": "https://schema.org",
          "@type": "Event",
          "name": "MA Print and MA Photography 2021: Double Vision &amp; After The High Tide",
          "startDate": "",
          "endDate": "",
          "eventStatus": "https://schema.org/EventScheduled",
          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
          "location": {
          
            "@type": "Place",
            "name": "External (UK)"
          
          },
          "image": "/media/images/Cromwell_Place.2e16d0ba.fill-1440x530.jpg",
          "description": "Double Vision &amp;amp; After The High Tide are satellite exhibitions showcasing the work of the 2021 MA Print and MA Photography graduates at Cromwell Place, London.",
          "organizer": {
            "@type": "Organization",
            "name": "Royal College of Art",
            "url": "https://rca.ac.uk"
          }
        }
    
```

After:

```
        {
          "@context": "https://schema.org",
          "@type": "Event",
          "name": "MA Print and MA Photography 2021: Double Vision &amp; After The High Tide",
          "startDate": "2025-10-31",
          "endDate": "2026-02-01",
          "eventStatus": "https://schema.org/EventScheduled",
          "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
          "location": {
          
            "@type": "Place",
            "name": "External (UK)"
          
          },
          "image": "/media/images/Cromwell_Place.2e16d0ba.fill-1440x530.jpg",
          "description": "Double Vision &amp;amp; After The High Tide are satellite exhibitions showcasing the work of the 2021 MA Print and MA Photography graduates at Cromwell Place, London.",
          "organizer": {
            "@type": "Organization",
            "name": "Royal College of Art",
            "url": "https://rca.ac.uk"
          }
        }
```

</p>
</details> 