### PR TITLE
Add trigram similarity search to search view

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -19,6 +19,12 @@ As much as possible, we want to use the official releases available on PyPI for 
 
 It is important to replace the usage of the git tags in the pyproject.toml file with the official release version from PyPI as soon as they become available.
 
+## PostgreSQL extensions
+
+### pg_trgm extension
+
+The `pg_trgm` extension is enabled via Django migration (`rca/search/migrations/0001_initial.py`) to support trigram similarity search. The similarity threshold is defined as a constant in `rca/search/views.py`.
+
 ## Critical paths
 
 The following areas of functionality are critical paths for the site which don't have full automated tests and should be checked manually.

--- a/rca/search/migrations/0001_initial.py
+++ b/rca/search/migrations/0001_initial.py
@@ -1,0 +1,17 @@
+# Generated manually as initial migration for search app
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.RunSQL(
+            "CREATE EXTENSION IF NOT EXISTS pg_trgm;",
+            "DROP EXTENSION IF EXISTS pg_trgm;",
+        ),
+    ]

--- a/rca/search/migrations/__init__.py
+++ b/rca/search/migrations/__init__.py
@@ -1,0 +1,1 @@
+# This file is intentionally empty to make the directory a Python package

--- a/rca/search/views.py
+++ b/rca/search/views.py
@@ -25,6 +25,8 @@ def search(request):
         query.add_hit()
 
         # If no results found, try trigram similarity search
+        # We can only filter by title, since that's the only field we have
+        # common to all page types.
         if not search_results:
             search_results = (
                 Page.objects.live()

--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -60,6 +60,7 @@ INSTALLED_APPS = [
     "rca.navigation",
     "rca.programmes",
     "rca.schools",
+    "rca.search",
     "rca.standardpages",
     "rca.users",
     "rca.utils",


### PR DESCRIPTION
Closes https://torchbox.atlassian.net/browse/R1-245

`pg_trgm` is enabled via migrations in the search app, so it should be available for all deployment envs. 

The threshold currently is set at 0.1 (as a constant in rca/search/views.py, which is quite forgiving. 