### PR TITLE
R1-250: EDITORIAL PAGE | Make Title Tag & Meta Description a required field

### DIFF
--- a/rca/editorial/admin_forms.py
+++ b/rca/editorial/admin_forms.py
@@ -1,7 +1,7 @@
-from wagtail.admin.forms import WagtailAdminPageForm
+from rca.utils.forms import RCAPageAdminForm
 
 
-class EditorialPageAdminForm(WagtailAdminPageForm):
+class EditorialPageAdminForm(RCAPageAdminForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["contact_model_title"].label = "Title"


### PR DESCRIPTION
Ticket: https://torchbox.atlassian.net/browse/R1-250

This PR makes the fields title tag and meta description in editorial page to be required.

<img width="952" height="494" alt="Screenshot 2025-08-05 at 10 14 17 AM" src="https://github.com/user-attachments/assets/827914b1-3c70-490b-a273-15a0179aea1d" />
