### PR TITLE
R1-322: ScholarshipsListingPage -  Add Home/Overseas toggle to filter bar (template, categories-tablist, toggle-switch atom, CSS)

### DIFF
--- a/rca/project_styleguide/templates/patterns/pages/scholarships/scholarships_listing_page.html
+++ b/rca/project_styleguide/templates/patterns/pages/scholarships/scholarships_listing_page.html
@@ -51,7 +51,7 @@
 
             <form class="section bg bg--{{ page.scholarships_listing_background_color }} js-tabs" method="get" action="#results" id="results">
                 <div class="section__row">
-                    <nav class="section filter-bar filter-bar--large {% if not results %}filter-bar--no-results-large{% endif %} " data-filter-bar>
+                    <nav class="section filter-bar filter-bar--large {% if result_count == 0 %}filter-bar--no-results-large{% endif %} " data-filter-bar>
                         <div class="grid">
                             <div class="layout__start-one layout__span-two layout__@large-start-two layout__@large-span-three">
                                 {% if page.scholarships_has_dark_background %}
@@ -75,7 +75,7 @@
                         </div>
                     </nav>
 
-                    <nav class="filter-bar filter-bar--small {% if not results %}filter-bar--no-results-small{% endif %} bg bg--light" data-filter-bar-small>
+                    <nav class="filter-bar filter-bar--small {% if result_count == 0 %}filter-bar--no-results-small{% endif %} bg bg--light" data-filter-bar-small>
                         <a class="filter-bar__link body body--two" href="#filters-active" data-filter-launcher>
                             <span class="filter-bar__label">Filters</span>
                             <svg width="12" height="8" class="filter-bar__icon" aria-hidden="true">
@@ -97,19 +97,22 @@
                     </div>
                 </div>
 
-                {% if results %}
-                    <div class="section__row grid">
-                        <div class="layout__start-one layout__span-two layout__@large-start-two layout__@large-span-three">
-                            {% if programme %}
-                                <p class="body body--one"><b>Scholarship results showing for {{ programme }} programme</b></p>
-                            {% endif %}
-                            <p class="body body--two">{{ page.characteristics_disclaimer }}</p>
-                        </div>
+                <div class="section__row grid">
+                    <h2 class="results-total results-total__heading heading heading--four layout__start-one layout__span-two layout__@large-start-two">
+                        {% if is_filtered %}
+                            <span class="results-total__type">Showing {{ result_count }} scholarship{{ result_count|pluralize }}</span>
+                        {% else %}
+                            <span class="results-total__type">Showing all scholarships</span>
+                            <span class="results-total__number">({{ result_count }})</span>
+                        {% endif %}
+                    </h2>
+                    <div class="layout__start-one layout__span-two layout__@large-start-two layout__@large-span-three">
+                        <p class="body body--two results-total__disclaimer">{{ page.characteristics_disclaimer }}</p>
                     </div>
-                    <div class="section__row section__row--last-small">
-                        {% include "patterns/organisms/accordion-block/accordion-block.html" with accordion_id='1' accordions=results title=results_title section_id=page.results_title|slugify scholarship=True %}
-                    </div>
-                {% endif %}
+                </div>
+                <div class="section__row section__row--last-small">
+                    {% include "patterns/organisms/accordion-block/accordion-block.html" with accordion_id='1' accordions=results title=results_title section_id=page.results_title|slugify scholarship=True %}
+                </div>
             </form>
 
             <section class="section bg bg--light">
@@ -119,7 +122,7 @@
                     </div>
                 {% endif %}
 
-                <div class="section__row section__row--last {% if not results %}section__row--first-small{% else %}section__row--first{% endif %} grid">
+                <div class="section__row section__row--last {% if result_count == 0 %}section__row--first-small{% else %}section__row--first{% endif %} grid">
                     <div class="streamfield rich-text layout__start-one layout__span-two layout__@large-start-two layout__@large-span-three">
                         {% include "patterns/molecules/streamfield/stream_block.html" with value=page.body guide_page=True %}
                     </div>

--- a/rca/scholarships/filters.py
+++ b/rca/scholarships/filters.py
@@ -1,6 +1,53 @@
 from rca.utils.filter import TabStyleFilter
 
 
+class FeeStatusFilter:
+    name = "fee-status"
+
+    def __init__(self):
+        self.tab_title = "Fee Status"
+        self.querydict = None
+        self.queryset = True  # truthy so the template {% if item.queryset %} passes
+
+    def apply(self, queryset, querydict):
+        self.querydict = querydict
+        fee_status = querydict.get(self.name)
+        if fee_status:
+            return queryset.filter(fee_statuses__slug=fee_status)
+        return queryset
+
+    @property
+    def selected_value(self):
+        if not self.querydict:
+            return None
+        return self.querydict.get(self.name)
+
+    @property
+    def is_selected(self):
+        return bool(self.selected_value)
+
+    @property
+    def filter_name(self):
+        return self.name
+
+    @property
+    def options(self):
+        yield from self
+
+    def __iter__(self):
+        from .models import ScholarshipFeeStatus
+
+        for fee_status in ScholarshipFeeStatus.objects.all():
+            yield {
+                "id": fee_status.slug,
+                "title": fee_status.title,
+                "active": self.selected_value == fee_status.slug,
+            }
+
+    def get_active_filters(self):
+        return [option for option in self.options if option["active"]]
+
+
 class ProgrammeTabStyleFilter(TabStyleFilter):
     def __iter__(self):
         # iter is overridden here so we can populate a title for the filter

--- a/rca/scholarships/models.py
+++ b/rca/scholarships/models.py
@@ -21,11 +21,10 @@ from wagtail.snippets.models import register_snippet
 
 from rca.programmes.models import ProgrammePage
 from rca.utils.blocks import CallToActionBlock, StepBlock
-from rca.utils.filter import TabStyleFilter
 from rca.utils.models import BasePage, ContactFieldsMixin, SluggedTaxonomy
 
 from .blocks import ScholarshipsListingPageBlock
-from .filters import ProgrammeTabStyleFilter
+from .filters import FeeStatusFilter, ProgrammeTabStyleFilter
 
 
 class ScholarshipFeeStatus(SluggedTaxonomy):
@@ -221,16 +220,7 @@ class ScholarshipsListingPage(ContactFieldsMixin, BasePage):
                 filter_by="eligable_programmes__slug__in",
                 option_value_field="slug",
             ),
-            TabStyleFilter(
-                "Fee Status",
-                queryset=(
-                    ScholarshipLocation.objects.filter(
-                        id__in=queryset.values_list("location_id", flat=True)
-                    )
-                ),
-                filter_by="location__slug__in",
-                option_value_field="slug",
-            ),
+            FeeStatusFilter(),
         )
 
         # Apply filters

--- a/rca/scholarships/models.py
+++ b/rca/scholarships/models.py
@@ -233,37 +233,38 @@ class ScholarshipsListingPage(ContactFieldsMixin, BasePage):
             ),
         )
 
-        if "programme" in request.GET or "location" in request.GET:
-            # Apply filters
-            for f in filters:
-                queryset = f.apply(queryset, request.GET)
+        # Apply filters
+        for f in filters:
+            queryset = f.apply(queryset, request.GET)
 
-            # Format scholarships for template
-            results = [
-                {
-                    "value": {
-                        "heading": s.title,
-                        "introduction": s.summary,
-                        "eligible_programmes": ", ".join(
-                            str(x) for x in s.eligable_programmes.live()
-                        ),
-                        "other_criteria": ", ".join(
-                            x.title for x in s.other_criteria.all()
-                        ),
-                        "fee_statuses": ", ".join(
-                            x.title for x in s.fee_statuses.all()
-                        ),
-                        "value": s.value,
-                    }
+        # Format scholarships for template
+        results = [
+            {
+                "value": {
+                    "heading": s.title,
+                    "introduction": s.summary,
+                    "eligible_programmes": ", ".join(
+                        str(x) for x in s.eligable_programmes.live()
+                    ),
+                    "other_criteria": ", ".join(
+                        x.title for x in s.other_criteria.all()
+                    ),
+                    "fee_statuses": ", ".join(x.title for x in s.fee_statuses.all()),
+                    "value": s.value,
                 }
-                for s in queryset
-            ]
+            }
+            for s in queryset
+        ]
 
-            # Template needs the programme for title and slug
-            try:
-                programme = ProgrammePage.objects.get(slug=request.GET["programme"])
-            except Exception:
-                pass
+        is_filtered = bool(
+            request.GET.get("programme") or request.GET.get("fee-status")
+        )
+
+        # Template needs the programme for title and slug
+        try:
+            programme = ProgrammePage.objects.get(slug=request.GET["programme"])
+        except Exception:
+            pass
 
         # Create the link for the sticky CTA
         interest_bar_link = reverse("scholarships:scholarship_enquiry_form")
@@ -285,6 +286,8 @@ class ScholarshipsListingPage(ContactFieldsMixin, BasePage):
             },
             programme=programme,
             results=results,
+            result_count=len(results),
+            is_filtered=is_filtered,
         )
         return context
 

--- a/rca/static_src/sass/components/_results-total.scss
+++ b/rca/static_src/sass/components/_results-total.scss
@@ -4,6 +4,14 @@
     $root: &;
     position: relative;
 
+    &__heading {
+        line-height: 40px;
+    }
+
+    &__disclaimer {
+        color: $color--dark-grey;
+    }
+
     &__anchor {
         position: absolute;
         top: -20px;


### PR DESCRIPTION
Ticket: https://torchbox.atlassian.net/browse/R1-323

This PR adds the home/overseas toggle to the scholarships listing filter bar. This is **not** hooked up to the BE yet.

<img width="1157" height="306" alt="Screenshot 2026-04-07 at 2 28 53 PM" src="https://github.com/user-attachments/assets/b0806ea8-cb24-415a-ba2b-37d68e78df1b" />
<img width="896" height="274" alt="Screenshot 2026-04-07 at 2 30 40 PM" src="https://github.com/user-attachments/assets/8453be4f-cedc-4f60-81a9-1a03851a645d" />
