### PR TITLE
R1-330: Bug with personalisation count down

### DIFF
--- a/rca/project_styleguide/templates/patterns/organisms/countdown_cta/countdown_cta.html
+++ b/rca/project_styleguide/templates/patterns/organisms/countdown_cta/countdown_cta.html
@@ -18,7 +18,7 @@
             </p>
             <p class="countdown-cta__title" id="countdown-cta-title">{{ value.title }}</p>
             {% if value.start_date and value.end_date %}
-                <p class="countdown-cta__date">{{ value.start_date|date:"j" }}-{{ value.end_date|date:"j" }} {{ value.end_date|date:"F" }}, {{ value.start_date|date:"g.iA"|lower }}, {{ value.end_date|date:"g.iA"|lower }}</p>
+                <p class="countdown-cta__date">{% if value.start_date|date:"FY" == value.end_date|date:"FY" %}{{ value.start_date|date:"j" }}-{{ value.end_date|date:"j" }} {{ value.end_date|date:"F" }}{% else %}{{ value.start_date|date:"j F" }} - {{ value.end_date|date:"j F" }}{% endif %}, {{ value.start_date|date:"g.iA"|lower }} - {{ value.end_date|date:"g.iA"|lower }}</p>
             {% elif value.start_date %}
                 <p class="countdown-cta__date">{{ value.start_date|date:"j F" }}, {{ value.start_date|date:"g.iA"|lower }}</p>
             {% elif value.end_date %}


### PR DESCRIPTION
Ticket: https://torchbox.atlassian.net/browse/R1-330

This PR updates the formatting of the event range in the event countdown CTA.

Within same month:

<img width="898" height="126" alt="Screenshot 2026-04-29 at 10 25 13 AM" src="https://github.com/user-attachments/assets/3dc9933c-d3c8-418c-a79b-8c73d82bc1a3" />

Through different months:

<img width="888" height="128" alt="Screenshot 2026-04-29 at 10 25 26 AM" src="https://github.com/user-attachments/assets/19a1caf8-e3ed-43f6-90d7-e62bf22d6b36" />