### PR TITLE
R1-236: TAP WIDGET | Does not display on Home page

### DIFF
--- a/rca/home/models.py
+++ b/rca/home/models.py
@@ -2,13 +2,13 @@ from collections import defaultdict
 
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.utils.safestring import mark_safe
 from wagtail.admin.panels import (
     FieldPanel,
     MultiFieldPanel,
     ObjectList,
     TabbedInterface,
 )
-from django.utils.safestring import mark_safe
 from wagtail.images import get_image_model_string
 
 from rca.home.blocks import HomePageBodyBlock

--- a/rca/home/models.py
+++ b/rca/home/models.py
@@ -8,6 +8,7 @@ from wagtail.admin.panels import (
     ObjectList,
     TabbedInterface,
 )
+from django.utils.safestring import mark_safe
 from wagtail.images import get_image_model_string
 
 from rca.home.blocks import HomePageBodyBlock
@@ -144,6 +145,9 @@ class HomePage(TapMixin, BasePage):
         context["processed_body"] = self.get_processed_body()
 
         context["hero_colour"] = LIGHT_HERO
+
+        if self.tap_widget:
+            context["tap_widget_code"] = mark_safe(self.tap_widget.script_code)
 
         if (
             hasattr(self, "hero_colour_option")


### PR DESCRIPTION
Ticket: https://torchbox.atlassian.net/browse/R1-326

This PR adds the missing TAP widget to the home page's context. It was probably removed when we made the home page to be flexible. Here's how it used to looked like (picked from a random commit): https://github.com/torchbox/rca-wagtail-2019/blob/2219748a1e29870a3dbc950011afc3e7b4e3510c/rca/home/models.py#L418.

See 'Chat now' in the bottom right:

<img width="1938" height="1167" alt="Screenshot 2026-04-29 at 1 24 53 PM" src="https://github.com/user-attachments/assets/f1c7e18f-97b7-43f6-bdba-f938ed15d1fa" />
