### PR TITLE
R1-332: Accessibility: Text contrast on story carousel module

### DIFF
--- a/rca/static_src/sass/components/_carousel.scss
+++ b/rca/static_src/sass/components/_carousel.scss
@@ -73,6 +73,22 @@
                 opacity: 0;
             }
         }
+
+        // Hide text content on inactive slides to avoid contrast failures.
+        // The opacity still applies to the image, but text is fully hidden
+        // until the slide is active
+        #{$root}__item {
+            .card__content-container {
+                opacity: 0;
+                transition: opacity 100ms ease-out;
+            }
+
+            &.glide__slide--active {
+                .card__content-container {
+                    opacity: 1;
+                }
+            }
+        }
     }
 
     &--quotes {


### PR DESCRIPTION
Ticket: https://torchbox.atlassian.net/browse/R1-332

This PR fixes the accessibility issue on story carousel by hiding the text content of inactive slides. Once active, it'll then be seen.

<img width="1912" height="1167" alt="Screenshot 2026-04-30 at 9 32 49 AM" src="https://github.com/user-attachments/assets/0b527913-f798-4398-b535-165ab9ad9f35" />
<img width="1912" height="1167" alt="Screenshot 2026-04-30 at 9 46 27 AM" src="https://github.com/user-attachments/assets/3ed38ce0-9bee-45ec-94a5-88eb4effa000" />
