### PR TITLE
R1-342: Urgent: internal links broken on programme pages

### DIFF
--- a/rca/project_styleguide/templates/patterns/organisms/programme_tabs/programme_overview.html
+++ b/rca/project_styleguide/templates/patterns/organisms/programme_tabs/programme_overview.html
@@ -1,3 +1,5 @@
+{% load wagtailcore_tags %}
+
 <section class="section section--start bg bg--dark">
 
     <div class="section__row programme-overview">
@@ -19,7 +21,7 @@
                     {% include "patterns/organisms/image-video-embed/image-video-embed.html" with modal=page.programme_video image=page.programme_image caption=page.programme_video_caption video=page.programme_video %}
                 {% endif %}
                 <div class="programme-overview__description rich-text">
-                    {{ page.programme_description_copy|safe }}
+                    {{ page.programme_description_copy|safe|richtext }}
                 </div>
                 {% if page.pathway_blocks %}
                     <div class="programme-overview__pathways">


### PR DESCRIPTION
Ticket: https://torchbox.atlassian.net/browse/R1-342

This PR fixes an issue with the programme description copy not rendering internal links.  The field is a rich text so we'll have to apply the rich text filter.

<img width="1838" height="1167" alt="Screenshot 2026-05-20 at 9 50 11 AM" src="https://github.com/user-attachments/assets/3c1f2d62-2a8d-419d-ac36-90210d5f6c0c" />

See bottom right that it's now linking to the internal page.