### PR TITLE
R1-343: Urgent: programme finder search not working

### DIFF
--- a/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammesResults.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesResults/ProgrammesResults.js
@@ -68,7 +68,7 @@ const ProgrammesResults = ({
     const { isFullTime, isPartTime } = useStudyMode();
 
     useEffect(() => {
-        if (hasActiveFilter || !!isFullTime || !!isPartTime) {
+        if (hasActiveFilter) {
             startSearch(null, { [activeCategory]: activeValue });
             const mount = document.querySelector(
                 '[data-mount-programmes-explorer]',

--- a/rca/static_src/javascript/programmes/programmes.routes.js
+++ b/rca/static_src/javascript/programmes/programmes.routes.js
@@ -61,15 +61,12 @@ export const getSearchURL = (search) => {
     const params = getParams();
     params.delete('category');
     params.delete('value');
-    params.delete('full-time');
-    params.delete('part-time');
     params.set('search', search);
     return getURL(params);
 };
 
 export const getCourseLengthURL = (isFullTime, isPartTime) => {
     const params = getParams();
-    params.delete('search');
     if (isFullTime === 'true') {
         params.set('full-time', 'true');
     } else {


### PR DESCRIPTION
Ticket: https://torchbox.atlassian.net/browse/R1-343

This PR fixes issues with searching and filtering in the programme finder page. It was confusing what was happening but the summary is:

  1. Searching clears the study mode - when searching, the page/JS was forgetting whether you'd selected full-time or part-time. Without that, the search refuses to run at all. This is why subsequent searches weren't happening.
  2. Changing study mode clears your search - this fixes a confusing behaviour of the search. 


https://github.com/user-attachments/assets/01b57c76-386f-4fde-88a9-f1bc102ad5b3

