### PR TITLE
Feature: Apple MDM Service Discovery Endpoint

### DIFF
--- a/rca/settings/base.py
+++ b/rca/settings/base.py
@@ -916,3 +916,6 @@ WAGTAIL_PERSONALISATION_RULES = [
     "wagtail_personalisation.OriginCountryRule",
     "personalisation.OriginContinentRule",
 ]
+
+# Feature flag for Apple MDM service discovery endpoint (/.well-known/com.apple.remotemanagement)
+APPLE_MDM_ENABLED = env.get("APPLE_MDM_ENABLED", "false").lower() == "true"

--- a/rca/urls.py
+++ b/rca/urls.py
@@ -18,6 +18,7 @@ from rca.account_management.views import (
 )
 from rca.search import views as search_views
 from rca.utils.cache import get_default_cache_control_decorator
+from rca.utils.views import apple_remote_management
 from rca.wagtailapi.api import api_router
 
 WAGTAIL_FRONTEND_LOGIN_TEMPLATE = getattr(
@@ -43,6 +44,7 @@ private_urlpatterns = [
 # Public URLs that are meant to be cached.
 urlpatterns = [
     path("sitemap.xml", sitemap),
+    path(".well-known/com.apple.remotemanagement", apple_remote_management),
     path("", include("social_django.urls", namespace="social")),
 ]
 

--- a/rca/utils/tests/test_views.py
+++ b/rca/utils/tests/test_views.py
@@ -4,14 +4,17 @@ from django.test import TestCase, override_settings
 
 
 class AppleRemoteManagementViewTest(TestCase):
+    @override_settings(APPLE_MDM_ENABLED=True)
     def test_returns_200(self):
         response = self.client.get("/.well-known/com.apple.remotemanagement")
         self.assertEqual(response.status_code, 200)
 
+    @override_settings(APPLE_MDM_ENABLED=True)
     def test_content_type_is_json(self):
         response = self.client.get("/.well-known/com.apple.remotemanagement")
         self.assertEqual(response["Content-Type"], "application/json")
 
+    @override_settings(APPLE_MDM_ENABLED=True)
     def test_response_body(self):
         response = self.client.get("/.well-known/com.apple.remotemanagement")
         data = json.loads(response.content)

--- a/rca/utils/tests/test_views.py
+++ b/rca/utils/tests/test_views.py
@@ -1,6 +1,6 @@
 import json
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 
 class AppleRemoteManagementViewTest(TestCase):
@@ -26,3 +26,8 @@ class AppleRemoteManagementViewTest(TestCase):
                 ]
             },
         )
+
+    @override_settings(APPLE_MDM_ENABLED=False)
+    def test_returns_404_when_disabled(self):
+        response = self.client.get("/.well-known/com.apple.remotemanagement")
+        self.assertEqual(response.status_code, 404)

--- a/rca/utils/tests/test_views.py
+++ b/rca/utils/tests/test_views.py
@@ -1,0 +1,28 @@
+import json
+
+from django.test import TestCase
+
+
+class AppleRemoteManagementViewTest(TestCase):
+    def test_returns_200(self):
+        response = self.client.get("/.well-known/com.apple.remotemanagement")
+        self.assertEqual(response.status_code, 200)
+
+    def test_content_type_is_json(self):
+        response = self.client.get("/.well-known/com.apple.remotemanagement")
+        self.assertEqual(response["Content-Type"], "application/json")
+
+    def test_response_body(self):
+        response = self.client.get("/.well-known/com.apple.remotemanagement")
+        data = json.loads(response.content)
+        self.assertEqual(
+            data,
+            {
+                "Servers": [
+                    {
+                        "BaseURL": "https://ios-mdm.google.com/userenrollment/enroll",
+                        "Version": "mdm-byod",
+                    }
+                ]
+            },
+        )

--- a/rca/utils/views.py
+++ b/rca/utils/views.py
@@ -1,3 +1,4 @@
+from django.http import JsonResponse
 from django.views import defaults
 
 
@@ -19,3 +20,16 @@ def page_not_found(request, exception, template_name="patterns/pages/errors/404.
 
 def server_error(request, template_name="patterns/pages/errors/500.html"):
     return defaults.server_error(request, template_name)
+
+
+def apple_remote_management(request):
+    return JsonResponse(
+        {
+            "Servers": [
+                {
+                    "BaseURL": "https://ios-mdm.google.com/userenrollment/enroll",
+                    "Version": "mdm-byod",
+                }
+            ]
+        }
+    )

--- a/rca/utils/views.py
+++ b/rca/utils/views.py
@@ -1,4 +1,5 @@
-from django.http import JsonResponse
+from django.conf import settings
+from django.http import Http404, JsonResponse
 from django.views import defaults
 
 
@@ -23,6 +24,10 @@ def server_error(request, template_name="patterns/pages/errors/500.html"):
 
 
 def apple_remote_management(request):
+    # If feature flag is disabled, raise 404.
+    if not getattr(settings, "APPLE_MDM_ENABLED", False):
+        raise Http404
+
     return JsonResponse(
         {
             "Servers": [


### PR DESCRIPTION
This PR adds a new endpoint to serve a service discovery JSON file to address the following:

> As part of our cyber essentials recertification - we are looking to improve how we manage personal devices assessing RCA data. We have come to a snag with iOS devices where it seems that there is a requirement to have a service discovery JSON file to be published on the RCA public website.