### PR TITLE
Trivy scan — R1-344

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -115,6 +115,18 @@ As well as testing the critical paths, these areas of functionality should be ch
 1. The site overrides the `/admin/logout/` endpoint to redirect users who logged in to `/logout/`. This is a confirmation screen that users will still need to manually log out of their SSO accounts. This is done with `rca.account_management.views.CustomLogoutView` and `rca.account_management.views.SSOLogoutConfirmationView`.
 2. Users who did not log in via SSO should be able to log out without seeing any confirmation screen.
 
+## Security / dependency review
+
+Last security review: 2026-06-16
+
+Run `trivy fs` from the project root each cycle. The project's real dependency surface is `poetry.lock` (Python) and `package-lock.json` (Node); Python and Node CVEs surfaced there are cleared by the quarterly version bumps and need no entry here once fixed.
+
+### Trivy false positives — `wagtail-personalisation` bundled `yarn.lock`
+
+`wagtail-personalisation` is installed from a Torchbox git fork (`pyproject.toml`, tag `0.16.0+tbx`), so an editable checkout lands in `.venv/src/wagtail-personalisation/`. That checkout carries the fork's own frontend `yarn.lock`, and a `trivy fs` scan from the project root reports its dev-toolchain CVEs (`fsevents`, `tar` 4.4.10, `debug`) against this project.
+
+These are **not project dependencies**: `.venv` is gitignored, the project consumes the package's built Python distribution rather than its JS build chain, and none of these packages appear in `package-lock.json`. They cannot be remediated from this repo — the versions are pinned by the upstream fork's `yarn.lock` at the tagged commit. Treat any `.venv/src/wagtail-personalisation/yarn.lock` finding as a scan-root false positive; it clears only when the fork tag advances (or the project drops the fork for an official PyPI release — see "Check these packages for updates" above).
+
 ---
 
 ## Overridden core Wagtail templates


### PR DESCRIPTION
# Trivy scan — R1-344

## Summary

Trivy fs scan on 2026-06-16: 28 findings (1 CRITICAL, 15 HIGH, 10 MEDIUM, 2 LOW). All findings on the project's real dependency surface (poetry.lock, package-lock.json) are cleared by the sibling sub-MRs in this integration run; the remaining findings are scan-root false positives from a git-fork editable install. This MR carries the security-section restamp in docs/upgrading.md plus a documented false-positive note. No CVE is accepted-and-held on the project's dependency surface.

## Findings requiring attention

- [ ] [.venv/src/wagtail-personalisation/yarn.lock — fsevents / tar 4.4.10 / debug (14 findings, CRITICAL + HIGH + MEDIUM + LOW) — scan-root false positive, documented in docs/upgrading.md. Not in the project Node tree (package-lock.json), .venv is gitignored, versions pinned by the upstream fork tag 0.16.0+tbx. Clears only when the fork tag advances or the project moves to a PyPI release.](https://github.com/torchbox-forks/wagtail-personalisation)

## Resolved by sibling sub-MRs (no action here)

poetry.lock — cryptography GHSA-537c-gmf6-5ccf and pyjwt CVE-2026-48522/48523/48524/48525/48526 are cleared by support/R1-344-bump-python-packages (cryptography ~46.0 to ~49.0; pyjwt relocked to 2.13.0). package-lock.json — js-cookie 2.2.1, picomatch, brace-expansion, ip-address and tar are cleared by support/R1-344-bump-node-packages (lockfile refresh; react-use 17.6.0 to 17.6.1 drops the nested js-cookie 2.2.1, top-level tar removed). The integration base does not yet include these bumps, so they are intentionally not re-fixed here to avoid conflicting lockfile diffs at merge.
