### PR TITLE
AHM-231: Fix programme finder crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-redux": "^9.3.0",
-        "react-transition-group": "^4.4.5",
         "react-use": "^17.6.1",
         "rellax": "^1.12.1",
         "rsync": "^0.6.1",
@@ -6875,6 +6874,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
       "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7948,16 +7948,6 @@
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
-      }
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -10229,6 +10219,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -17642,22 +17633,6 @@
         "redux": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/react-universal-interface": {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-redux": "^9.3.0",
-    "react-transition-group": "^4.4.5",
     "react-use": "^17.6.1",
     "rellax": "^1.12.1",
     "rsync": "^0.6.1",

--- a/rca/static_src/javascript/programmes/components/ProgrammesExplorer.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesExplorer.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useRef, useState } from 'react';
-import { CSSTransition, TransitionGroup } from 'react-transition-group';
+import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-use';
 
 import { programmeCategories } from '../programmes.types';
@@ -20,17 +19,13 @@ const ProgrammesExplorer = ({ searchLabel, categories }) => {
     const activeCategory = params.get('category') || categories[0].id;
     const filterValue = params.get('value') || '';
     const activeValue = filterValue.split('-')[0];
-    const hasActiveCategoryFilter = !!activeValue;
     const searchQuery = params.get('search') || '';
-    const hasActiveSearch = !!searchQuery;
-    const showCategories = !hasActiveCategoryFilter && !hasActiveSearch;
-    const showResults = hasActiveCategoryFilter || hasActiveSearch;
+    // The explorer is a two-state toggle: either you are browsing the
+    // categories, or you are looking at the results of a filter or a search.
+    const showResults = Boolean(activeValue || searchQuery);
 
     const [isFullTime, setIsFullTime] = useState(params.get('full-time') || '');
     const [isPartTime, setIsPartTime] = useState(params.get('part-time') || '');
-
-    const categoriesNodeRef = useRef(null);
-    const resultsNodeRef = useRef(null);
 
     /* eslint-disable react-hooks/exhaustive-deps */
     useEffect(() => {
@@ -52,50 +47,26 @@ const ProgrammesExplorer = ({ searchLabel, categories }) => {
             }}
         >
             <SearchForm searchQuery={searchQuery} label={searchLabel} />
-            <TransitionGroup className="explorer-transitions">
-                {showCategories ? (
-                    <CSSTransition
-                        key="categories"
-                        nodeRef={categoriesNodeRef}
-                        classNames="categories-transition"
-                        timeout={500}
-                        in={showCategories}
-                        mountOnEnter
-                        unmountOnExit
-                    >
-                        <div ref={categoriesNodeRef}>
-                            <ProgrammesCategories
-                                categories={categories}
-                                activeCategory={activeCategory}
-                                isFullTime={isFullTime === 'true'}
-                                isPartTime={isPartTime === 'true'}
-                            />
-                        </div>
-                    </CSSTransition>
-                ) : null}
+            {/* Whichever view mounts fades itself in — see _programmes-explorer.scss. */}
+            <div className="explorer-transitions">
                 {showResults ? (
-                    <CSSTransition
-                        key="results"
-                        nodeRef={resultsNodeRef}
-                        classNames="results-transition"
-                        timeout={500}
-                        in={showResults}
-                        mountOnEnter
-                        unmountOnExit
-                    >
-                        <div ref={resultsNodeRef}>
-                            <ProgrammesResults
-                                categories={categories}
-                                activeCategory={activeCategory}
-                                activeValue={activeValue}
-                                searchQuery={searchQuery}
-                                isFullTime={isFullTime === 'true'}
-                                isPartTime={isPartTime === 'true'}
-                            />
-                        </div>
-                    </CSSTransition>
-                ) : null}
-            </TransitionGroup>
+                    <ProgrammesResults
+                        categories={categories}
+                        activeCategory={activeCategory}
+                        activeValue={activeValue}
+                        searchQuery={searchQuery}
+                        isFullTime={isFullTime === 'true'}
+                        isPartTime={isPartTime === 'true'}
+                    />
+                ) : (
+                    <ProgrammesCategories
+                        categories={categories}
+                        activeCategory={activeCategory}
+                        isFullTime={isFullTime === 'true'}
+                        isPartTime={isPartTime === 'true'}
+                    />
+                )}
+            </div>
         </StudyModeContext.Provider>
     );
 };

--- a/rca/static_src/javascript/programmes/components/ProgrammesExplorer.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesExplorer.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { useLocation } from 'react-use';
 
@@ -29,6 +29,9 @@ const ProgrammesExplorer = ({ searchLabel, categories }) => {
     const [isFullTime, setIsFullTime] = useState(params.get('full-time') || '');
     const [isPartTime, setIsPartTime] = useState(params.get('part-time') || '');
 
+    const categoriesNodeRef = useRef(null);
+    const resultsNodeRef = useRef(null);
+
     /* eslint-disable react-hooks/exhaustive-deps */
     useEffect(() => {
         // Only do this on initial load
@@ -53,37 +56,43 @@ const ProgrammesExplorer = ({ searchLabel, categories }) => {
                 {showCategories ? (
                     <CSSTransition
                         key="categories"
+                        nodeRef={categoriesNodeRef}
                         classNames="categories-transition"
                         timeout={500}
                         in={showCategories}
                         mountOnEnter
                         unmountOnExit
                     >
-                        <ProgrammesCategories
-                            categories={categories}
-                            activeCategory={activeCategory}
-                            isFullTime={isFullTime === 'true'}
-                            isPartTime={isPartTime === 'true'}
-                        />
+                        <div ref={categoriesNodeRef}>
+                            <ProgrammesCategories
+                                categories={categories}
+                                activeCategory={activeCategory}
+                                isFullTime={isFullTime === 'true'}
+                                isPartTime={isPartTime === 'true'}
+                            />
+                        </div>
                     </CSSTransition>
                 ) : null}
                 {showResults ? (
                     <CSSTransition
                         key="results"
+                        nodeRef={resultsNodeRef}
                         classNames="results-transition"
                         timeout={500}
                         in={showResults}
                         mountOnEnter
                         unmountOnExit
                     >
-                        <ProgrammesResults
-                            categories={categories}
-                            activeCategory={activeCategory}
-                            activeValue={activeValue}
-                            searchQuery={searchQuery}
-                            isFullTime={isFullTime === 'true'}
-                            isPartTime={isPartTime === 'true'}
-                        />
+                        <div ref={resultsNodeRef}>
+                            <ProgrammesResults
+                                categories={categories}
+                                activeCategory={activeCategory}
+                                activeValue={activeValue}
+                                searchQuery={searchQuery}
+                                isFullTime={isFullTime === 'true'}
+                                isPartTime={isPartTime === 'true'}
+                            />
+                        </div>
                     </CSSTransition>
                 ) : null}
             </TransitionGroup>

--- a/rca/static_src/javascript/programmes/components/ProgrammesExplorer.test.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesExplorer.test.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+
+import ProgrammesExplorer from './ProgrammesExplorer';
+import programmesReducer from '../programmes.slice';
+
+const getMockCategories = () => [
+    {
+        id: 'discipline',
+        title: 'Discipline',
+        items: [
+            {
+                id: 1,
+                title: 'Architecture',
+                description: 'Architecture programmes',
+                slug: 'architecture',
+            },
+        ],
+    },
+];
+
+const renderExplorer = () => {
+    const store = configureStore({
+        reducer: { programmes: programmesReducer },
+    });
+
+    return render(
+        <Provider store={store}>
+            <ProgrammesExplorer
+                searchLabel="Search"
+                categories={getMockCategories()}
+            />
+        </Provider>,
+    );
+};
+
+describe('ProgrammesExplorer', () => {
+    beforeEach(() => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({ json: () => Promise.resolve({ items: [] }) }),
+        );
+    });
+
+    afterEach(() => {
+        delete global.fetch;
+    });
+
+    // Regression test: selecting a category used to crash the whole explorer
+    // with "ReactDOM.findDOMNode is not a function", because react-dom 19
+    // removed findDOMNode and react-transition-group's CSSTransition falls
+    // back to it whenever no nodeRef prop is provided.
+    it('switches from categories to results when a category item is selected', async () => {
+        renderExplorer();
+
+        await userEvent.click(
+            screen.getByRole('link', { name: /^Architecture/ }),
+        );
+
+        expect(
+            screen.getByRole('heading', { name: 'Exploring by' }),
+        ).toBeInTheDocument();
+    });
+});

--- a/rca/static_src/javascript/programmes/components/ProgrammesExplorer.test.js
+++ b/rca/static_src/javascript/programmes/components/ProgrammesExplorer.test.js
@@ -39,6 +39,11 @@ const renderExplorer = () => {
 
 describe('ProgrammesExplorer', () => {
     beforeEach(() => {
+        // The explorer drives its state through the URL via pushState, which
+        // persists across tests in this file. Reset it, or each test inherits
+        // wherever the previous one navigated to.
+        window.history.pushState({}, '', '/');
+
         global.fetch = jest.fn(() =>
             Promise.resolve({ json: () => Promise.resolve({ items: [] }) }),
         );
@@ -50,8 +55,9 @@ describe('ProgrammesExplorer', () => {
 
     // Regression test: selecting a category used to crash the whole explorer
     // with "ReactDOM.findDOMNode is not a function", because react-dom 19
-    // removed findDOMNode and react-transition-group's CSSTransition falls
-    // back to it whenever no nodeRef prop is provided.
+    // removed findDOMNode and react-transition-group's CSSTransition fell back
+    // to it whenever no nodeRef prop was provided. The explorer no longer uses
+    // react-transition-group at all — the fade is pure CSS.
     it('switches from categories to results when a category item is selected', async () => {
         renderExplorer();
 
@@ -62,5 +68,28 @@ describe('ProgrammesExplorer', () => {
         expect(
             screen.getByRole('heading', { name: 'Exploring by' }),
         ).toBeInTheDocument();
+    });
+
+    it('shows exactly one of the two views at a time', async () => {
+        const { container } = renderExplorer();
+
+        const views = () =>
+            container.querySelectorAll(
+                '.programmes-categories, .programmes-results__wrapper',
+            );
+
+        expect(views()).toHaveLength(1);
+        expect(
+            container.querySelector('.programmes-categories'),
+        ).not.toBeNull();
+
+        await userEvent.click(
+            screen.getByRole('link', { name: /^Architecture/ }),
+        );
+
+        expect(views()).toHaveLength(1);
+        expect(
+            container.querySelector('.programmes-results__wrapper'),
+        ).not.toBeNull();
     });
 });

--- a/rca/static_src/sass/components/_programmes-explorer.scss
+++ b/rca/static_src/sass/components/_programmes-explorer.scss
@@ -2,55 +2,28 @@
 
 .explorer-transitions {
     position: relative;
-}
 
-.results-transition {
-    &-enter {
-        .programmes-results__actions {
+    @keyframes explorerFadeIn {
+        from {
             opacity: 0;
         }
-    }
 
-    &-enter-active {
-        .programmes-results__actions {
-            opacity: 1;
-            transition: opacity 500ms ease-out;
-        }
-    }
-
-    &-exit {
-        .programmes-results__actions {
+        to {
             opacity: 1;
         }
     }
 
-    &-exit-active {
+    // Switching between the categories view and the results view remounts the
+    // view, so the animation runs once each time one is shown.
+    .categories-panels,
+    .programmes-results__actions {
+        animation: explorerFadeIn 500ms ease-out;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .categories-panels,
         .programmes-results__actions {
-            opacity: 0;
-            transition: opacity 500ms ease-out;
+            animation: none;
         }
-    }
-}
-
-.categories-transition {
-    &-enter {
-        .categories-panels {
-            opacity: 0;
-        }
-    }
-
-    &-enter-active {
-        .categories-panels {
-            opacity: 1;
-            transition: opacity 500ms ease-out;
-        }
-    }
-
-    &-exit {
-        display: block;
-    }
-
-    &-exit-active {
-        display: none;
     }
 }


### PR DESCRIPTION
Fixes [AHM-231](https://torchbox.atlassian.net/browse/AHM-231)

## Summary

- The programme-finder page crashes on category/search selection with `Uncaught TypeError: ReactDOM.findDOMNode is not a function`.
- This was introduced when _react-dom_ was bumped from version 18.x to 19.2.7, as part of recent Node dependency upgrade work. Version 19 removed `findDOMNode` entirely.
  - `react-transition-group@4.4.5` (the most recent release, [unmaintained since 2021](https://github.com/reactjs/react-transition-group) and incompatible with React 19 by default) falls back to calling it internally whenever a `<CSSTransition>` doesn't receive a `nodeRef` prop, which was the case for both `CSSTransition` elements in `ProgrammesExplorer.js`.
- Fixed by removing _react-transition-group_ entirely, replacing the two opacity fades it provided with plain CSS animations.
  - This removes all the transition machinery: `TransitionGroup`, both `CSSTransition` wrappers, and the `in` prop each depended on. It also drops one of the two mirrored booleans: `showCategories` and `showResults` were always opposites, so tracking both was redundant. This leaves a single `showResults ? <ProgrammesResults /> : <ProgrammesCategories />` ternary.

## Behaviour changes

Checked side by side against staging content:

- Fade-in of the categories panel and the results actions is unchanged (opacity 0 → 1 over 500ms, ease-out).
- Categories exit is unchanged — the old `display: block` → `display: none` was never animatable, so it was always an instant hide.
- Going back to categories no longer holds the results view mounted at full opacity for 500ms. That overlap used to stack two `bg--dark` sections, reading as a brief darkening rather than a crossfade.
- The categories panel now fades in on first load too: this was previously suppressed by `TransitionGroup`'s `appear={false}`.
- Added a `prefers-reduced-motion` guard, matching the rest of the codebase.

### Test plan

- [x] Added a regression test (`ProgrammesExplorer.test.js`) that selects a category item and asserts the explorer doesn't crash (reproduces the original bug before either fix).
- [x] Added a second test asserting exactly one of the categories/results views is mounted at a time.
- [x] Reset the URL between tests (pushState state was leaking across tests in this file).
- [x] Full JS test suite passes.
- [x] eslint/prettier clean.